### PR TITLE
Update the readme and sort out the tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # unifi-docker
-Unifi Docker files
+
+## Description
+
+This is a containerized version of [Ubiqiti Network](https://www.ubnt.com/)'s Unifi Controller.
+
+Included tags for unifi5, unifi4, stable, unifi3 and oldstable. Latest currently points to the unifi5 version.
+
+Use `docker run --net=host -d jacobalberty/unifi:latest` for the quickest setup
+
+## Supported tags and respective `Dockerfile` links
+
+[`unifi3`, `oldstable` (_unifi3/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi3/Dockerfile)
+
+[`unifi4`, `stable` (_unifi4/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi4/Dockerfile)
+
+[`unifi5`, `latest` (_unifi5/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi5/Dockerfile)
+
+## Volumes:
+
+### `/var/lib/unifi`
+
+Configuration data
+
+### `/var/log/unifi`
+
+Log Files
+
+### `/var/run/unifi`
+
+Run Information
+
+## Environment Variables:
+
+### `TZ`
+
+TimeZone. (i.e America/Chicago)
+
+## Expose:
+
+### 8080/tcp
+
+### 8081/tcp
+
+### 8443/tcp
+
+### 8843/tcp
+
+### 8880/tcp
+
+### 3478/udp

--- a/unifi3/README.md
+++ b/unifi3/README.md
@@ -1,38 +1,51 @@
-#docker UniFi
+# unifi-docker
+
+## Description
+
+This is a containerized version of [Ubiqiti Network](https://www.ubnt.com/)'s Unifi Controller.
+
+Included tags for unifi5, unifi4, stable, unifi3 and oldstable. Latest currently points to the unifi5 version.
+
+Use `docker run --net=host -d jacobalberty/unifi:latest` for the quickest setup
 
 ## Supported tags and respective `Dockerfile` links
 
-[`unifi3`, `oldstable` (*unifi3/Dockerfile*)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi3/Dockerfile)
+[`unifi3`, `oldstable` (_unifi3/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi3/Dockerfile)
 
-[`unifi4`, `stable`, `latest` (*unifi4/Dockerfile*)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi4/Dockerfile)
+[`unifi4`, `stable` (_unifi4/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi4/Dockerfile)
 
-[`unifi5`, `stable`, `latest` (*unifi4/Dockerfile*)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi5/Dockerfile)
-
-## Description 
-This is a containerized version of the Unifi Access Point controller.
-I have included tags for unifi5, unifi4, stable, unifi3 and oldstable. Latest points to the unifi5 version.
-
-Use `docker run --net=host -d jacobalberty/unifi:rapid` for the quickest setup
+[`unifi5`, `latest` (_unifi5/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi5/Dockerfile)
 
 ## Volumes:
 
 ### `/var/lib/unifi`
+
 Configuration data
 
 ### `/var/log/unifi`
+
 Log Files
 
 ### `/var/run/unifi`
+
 Run Information
 
 ## Environment Variables:
+
 ### `TZ`
+
 TimeZone. (i.e America/Chicago)
 
 ## Expose:
+
 ### 8080/tcp
+
 ### 8081/tcp
+
 ### 8443/tcp
+
 ### 8843/tcp
+
 ### 8880/tcp
+
 ### 3478/udp

--- a/unifi4/README.md
+++ b/unifi4/README.md
@@ -1,38 +1,51 @@
-#docker UniFi
+# unifi-docker
+
+## Description
+
+This is a containerized version of [Ubiqiti Network](https://www.ubnt.com/)'s Unifi Controller.
+
+Included tags for unifi5, unifi4, stable, unifi3 and oldstable. Latest currently points to the unifi5 version.
+
+Use `docker run --net=host -d jacobalberty/unifi:latest` for the quickest setup
 
 ## Supported tags and respective `Dockerfile` links
 
-[`unifi3`, `oldstable` (*unifi3/Dockerfile*)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi3/Dockerfile)
+[`unifi3`, `oldstable` (_unifi3/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi3/Dockerfile)
 
-[`unifi4`, `stable`, `latest` (*unifi4/Dockerfile*)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi4/Dockerfile)
+[`unifi4`, `stable` (_unifi4/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi4/Dockerfile)
 
-[`unifi5`, `stable`, `latest` (*unifi4/Dockerfile*)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi5/Dockerfile)
-
-## Description 
-This is a containerized version of the Unifi Access Point controller.
-I have included tags for unifi5, unifi4, stable, unifi3 and oldstable. Latest points to the unifi5 version.
-
-Use `docker run --net=host -d jacobalberty/unifi:rapid` for the quickest setup
+[`unifi5`, `latest` (_unifi5/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi5/Dockerfile)
 
 ## Volumes:
 
 ### `/var/lib/unifi`
+
 Configuration data
 
 ### `/var/log/unifi`
+
 Log Files
 
 ### `/var/run/unifi`
+
 Run Information
 
 ## Environment Variables:
+
 ### `TZ`
+
 TimeZone. (i.e America/Chicago)
 
 ## Expose:
+
 ### 8080/tcp
+
 ### 8081/tcp
+
 ### 8443/tcp
+
 ### 8843/tcp
+
 ### 8880/tcp
+
 ### 3478/udp

--- a/unifi5/README.md
+++ b/unifi5/README.md
@@ -1,38 +1,51 @@
-#docker UniFi
+# unifi-docker
+
+## Description
+
+This is a containerized version of [Ubiqiti Network](https://www.ubnt.com/)'s Unifi Controller.
+
+Included tags for unifi5, unifi4, stable, unifi3 and oldstable. Latest currently points to the unifi5 version.
+
+Use `docker run --net=host -d jacobalberty/unifi:latest` for the quickest setup
 
 ## Supported tags and respective `Dockerfile` links
 
-[`unifi3`, `oldstable` (*unifi3/Dockerfile*)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi3/Dockerfile)
+[`unifi3`, `oldstable` (_unifi3/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi3/Dockerfile)
 
-[`unifi4`, `stable`, `latest` (*unifi4/Dockerfile*)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi4/Dockerfile)
+[`unifi4`, `stable` (_unifi4/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi4/Dockerfile)
 
-[`unifi5`, `stable`, `latest` (*unifi4/Dockerfile*)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi5/Dockerfile)
-
-## Description 
-This is a containerized version of the Unifi Access Point controller.
-I have included tags for unifi5, unifi4, stable, unifi3 and oldstable. Latest points to the unifi5 version.
-
-Use `docker run --net=host -d jacobalberty/unifi:rapid` for the quickest setup
+[`unifi5`, `latest` (_unifi5/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi5/Dockerfile)
 
 ## Volumes:
 
 ### `/var/lib/unifi`
+
 Configuration data
 
 ### `/var/log/unifi`
+
 Log Files
 
 ### `/var/run/unifi`
+
 Run Information
 
 ## Environment Variables:
+
 ### `TZ`
+
 TimeZone. (i.e America/Chicago)
 
 ## Expose:
+
 ### 8080/tcp
+
 ### 8081/tcp
+
 ### 8443/tcp
+
 ### 8843/tcp
+
 ### 8880/tcp
+
 ### 3478/udp


### PR DESCRIPTION
In my PR last night I had one place that I missed updating unifi4 to unifi5.
I took the oppertunity to clean up the readme a bit while fixing it.

You'll also notice that I updated the tags referenced in the README with
what I thought made sense but let me know if you need me to update this PR
or feel free to pull this into your own branch and update this further.

I left the stable on unifi4 and oldstable on unifi3 as moving
that tag could suprise some users.

It seems as though the new builds on the docker hub don't have the expected tags
for some users.  As the unifi5 tag doesn't exist.

I wasn't sure how the automated build stuff worked so I left the README.md's in
each sub folder.  But they seem redundant and all but the main one could be
removed.