### PR TITLE
Update apt-get install command to include --no-install-recommends to reduce size

### DIFF
--- a/unifi5/Dockerfile
+++ b/unifi5/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti" > \
   apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
 
 RUN apt-get -q update && \
-  apt-get install -qy --force-yes unifi && \
+  apt-get install -qy --force-yes --no-install-recommends unifi && \
   apt-get -q clean && \
   rm -rf /var/lib/apt/lists/*
 
@@ -21,11 +21,11 @@ RUN ln -s /var/lib/unifi /usr/lib/unifi/data
 EXPOSE 8080/tcp 8081/tcp 8443/tcp 8843/tcp 8880/tcp 3478/udp
 
 ## Uncommenting these allows unifi to run as user nobody but I don't know for sure that all features work so leaving commented out for now
-# RUN chown -R nobody.nogroup /usr/lib/unifi && \
-#    chown -R nobody.nogroup /var/lib/unifi && \
-#    chown -R nobody.nogroup /var/log/unifi && \
-#    chown -R nobody.nogroup /var/run/unifi
-# USER nobody
+#RUN chown -R nobody:nogroup /usr/lib/unifi && \
+#    chown -R nobody:nogroup /var/lib/unifi && \
+#    chown -R nobody:nogroup /var/log/unifi && \
+#    chown -R nobody:nogroup /var/run/unifi
+#USER nobody
 
 WORKDIR /var/lib/unifi
 


### PR DESCRIPTION
Another day another PR.  Sorry these changes are trickling in like this.

This change shrinks the resulting container by 10%.  I only did this to the unifi5 Dockerfile as it's the only one I've tested with this.  But this smaller container is running fine for me.  But I only use this with Unifi APs.  I don't have any UGW or VOIP devices from Ubnt.

```
3dinfluence/unifi         latest              37150df23d56        3 minutes ago       499.4 MB
jacobalberty/unifi    latest              e6a71a8c5863        5 hours ago         555.6 MB
```

Packages that are no longer installed as of 2016-06-03
```
dbus amd64 1.8.20-0+deb8u1 [291 kB]
default-jre-headless amd64 2:1.7-52 [9072 B]
krb5-locales all 1.12.1+dfsg-19+deb8u2 [2649 kB]
libalgorithm-c3-perl all 0.09-1 [11.9 kB]
libarchive-extract-perl all 0.72-1 [24.8 kB]
libcap-ng0 amd64 0.7.4-2 [13.2 kB]
libcgi-fast-perl all 1:2.04-1 [10.9 kB]
libcgi-pm-perl all 4.09-1 [213 kB]
libclass-c3-perl all 0.26-1 [22.9 kB]
libclass-c3-xs-perl amd64 0.13-2+b1 [15.2 kB]
libcpan-meta-perl all 2.142690-1 [125 kB]
libdata-optlist-perl all 0.109-1 [10.6 kB]
libdata-section-perl all 0.200006-1 [13.4 kB]
libfcgi-perl amd64 0.77-1+b1 [39.1 kB]
libgdbm3 amd64 1.8.3-13.1 [30.0 kB]
libglib2.0-data all 2.42.1-1 [2173 kB]
liblog-message-perl all 0.8-1 [26.0 kB]
liblog-message-simple-perl all 0.10-2 [8126 B]
libmodule-build-perl all 0.421000-2 [265 kB]
libmodule-pluggable-perl all 5.1-1 [25.0 kB]
libmodule-signature-perl all 0.73-1+deb8u2 [30.4 kB]
libmro-compat-perl all 0.12-1 [13.2 kB]
libpackage-constants-perl all 0.04-1 [5820 B]
libparams-util-perl amd64 1.07-2+b1 [23.5 kB]
libpod-latex-perl all 0.61-1 [34.7 kB]
libpod-readme-perl all 0.11-1 [15.3 kB]
libregexp-common-perl all 2013031301-1 [173 kB]
libsoftware-license-perl all 0.103010-3 [119 kB]
libsub-exporter-perl all 0.986-1 [49.9 kB]
libsub-install-perl all 0.928-1 [11.4 kB]
libterm-ui-perl all 0.42-1 [19.1 kB]
libtext-soundex-perl amd64 3.4-1+b2 [13.7 kB]
libtext-template-perl all 1.46-1 [53.1 kB]
libxml2 amd64 2.9.1+dfsg1-5+deb8u2 [802 kB]
lksctp-tools amd64 1.0.16+dfsg-2 [62.6 kB]
perl amd64 5.20.2-3+deb8u4 [2638 kB]
perl-modules all 5.20.2-3+deb8u4 [2546 kB]
rename all 0.20-3 [12.4 kB]
sgml-base all 1.26+nmu4 [14.6 kB]
shared-mime-info amd64 1.3-1 [634 kB]
tcpd amd64 7.6.q-25 [22.9 kB]
xdg-user-dirs amd64 0.15-2 [52.1 kB]
xml-core all 0.13+nmu2 [24.2 kB]
```