### PR TITLE
fixed issue #12 and refactored how unifi processes are run

### DIFF
--- a/unifi5/Dockerfile
+++ b/unifi5/Dockerfile
@@ -1,33 +1,70 @@
 FROM debian:jessie
+  # WORKING: ends up being 500MB+
+# FROM openjdk:8-jdk
+  # openjdk:8-jdk might sound like a good alternative, currently based on debian jessie, but Docker could switch that to apline some day? It's 600MB+!!
+# FROM debian:jessie-slim
+  # NOT WORKING. seems to cause issues when installing openjdk when update-alternatives tries to link a man page and breaks just because man pages are not installed. `--force-all` might work arround it, but that's a hack... :-/
+
 MAINTAINER Jacob Alberty <jacob.alberty@foundigital.com>
 
-VOLUME ["/var/lib/unifi", "/var/log/unifi", "/var/run/unifi", "/usr/lib/unifi/work"]
+ENV DEBIAN_FRONTEND noninteractive \
+  container=docker
 
-ENV DEBIAN_FRONTEND noninteractive
+# Need backports for openjdk-8
+RUN echo "deb http://httpredir.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/10backports.list && \
+  echo "deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti" > /etc/apt/sources.list.d/20ubiquiti.list && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv C0A52C50
+  # rather stick to what ubiquity themselves likely test with
+  #echo "deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen" > \
+  #/etc/apt/sources.list.d/21mongodb.list && \
+  #apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
 
-RUN echo "deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti" > \
-  /etc/apt/sources.list.d/20ubiquiti.list && \
-  echo "deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen" > \
-  /etc/apt/sources.list.d/21mongodb.list && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv C0A52C50 && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
-
-RUN apt-get -q update && \
-  apt-get install -qy --force-yes --no-install-recommends unifi && \
-  apt-get -q clean && \
+# Push installing openjdk-8-jre first, so that the unifi package doesn't pull in openjdk-7-jre as a dependency? Else uncomment and just go with openjdk-7.
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends openjdk-8-jre-headless && \
+  apt-get install -y --no-install-recommends unifi && \
+  apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /var/lib/unifi /usr/lib/unifi/data
-EXPOSE 6789/tcp 8080/tcp 8081/tcp 8443/tcp 8843/tcp 8880/tcp 3478/udp
+ADD 'https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb' /tmp/dumb-init_1.2.0_amd64.deb
+RUN  dpkg -i /tmp/dumb-init_*.deb && \
+  rm /tmp/dumb-init_*.deb
 
-## Uncommenting these allows unifi to run as user nobody but I don't know for sure that all features work so leaving commented out for now
+ENV BASEDIR=/usr/lib/unifi \
+  DATADIR=/var/lib/unifi \
+  RUNDIR=/var/run/unifi \
+  LOGDIR=/var/log/unifi \
+  JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
+  JVM_MAX_HEAP_SIZE=1024M \
+  JVM_INIT_HEAP_SIZE=
+
+RUN ln -s ${BASEDIR}/data ${DATADIR} && \
+  ln -s ${BASEDIR}/run ${RUNDIR} && \
+  ln -s ${BASEDIR}/logs ${LOGDIR}
+# Can't use env var, RUN doesn't support them?
+
+VOLUME ["${DATADIR}", "${RUNDIR}", "${LOGDIR}"]
+# not sure if "/usr/lib/unifi/work" is needed as well?
+
+#EXPOSE 6789/tcp 8080/tcp 8081/tcp 8443/tcp 8843/tcp 8880/tcp 3478/udp
+EXPOSE 6789/tcp 8080/tcp 8443/tcp 8880/tcp 8843/tcp 3478/udp
+
+## Uncommenting these allows unifi to run as user nobody but I don't know for sure that all features #work so leaving commented out for now
 #RUN chown -R nobody:nogroup /usr/lib/unifi && \
 #    chown -R nobody:nogroup /var/lib/unifi && \
 #    chown -R nobody:nogroup /var/log/unifi && \
 #    chown -R nobody:nogroup /var/run/unifi
 #USER nobody
 
+COPY unifi.sh /usr/local/bin/
+
 WORKDIR /var/lib/unifi
 
-ENTRYPOINT ["/usr/bin/java", "-Xmx1024M", "-jar", "/usr/lib/unifi/lib/ace.jar"]
-CMD ["start"]
+# execute controller using JSVC like orignial debian package does
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/usr/local/bin/unifi.sh"]
+
+# execute the conroller directly without using the service
+#ENTRYPOINT ["/usr/bin/java", "-Xmx${JVM_MAX_HEAP_SIZE}", "-jar", "/usr/lib/unifi/lib/ace.jar"]
+  # See issue #12 on github: probably want to consider how JSVC handled creating multiple processes, issuing the -stop instraction, etc. Not sure if the above ace.jar class gracefully handles TERM signals.
+#CMD ["start"]

--- a/unifi5/README.md
+++ b/unifi5/README.md
@@ -2,19 +2,11 @@
 
 ## Description
 
-This is a containerized version of [Ubiqiti Network](https://www.ubnt.com/)'s Unifi Controller.
+This is a containerized version of [Ubiqiti Network](https://www.ubnt.com/)'s Unifi Controller version 5.
 
-Included tags for unifi5, unifi4, stable, unifi3 and oldstable. Latest currently points to the unifi5 version.
+Use `docker run --net=host -d jacobalberty/unifi:unifi5` to run it.
 
-Use `docker run --net=host -d jacobalberty/unifi:latest` for the quickest setup
-
-## Supported tags and respective `Dockerfile` links
-
-[`unifi3`, `oldstable` (_unifi3/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi3/Dockerfile)
-
-[`unifi4`, `stable` (_unifi4/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi4/Dockerfile)
-
-[`unifi5`, `latest` (_unifi5/Dockerfile_)](https://github.com/jacobalberty/unifi-docker/blob/master/unifi5/Dockerfile)
+Add in `-e TZ='Africa/Johannesburg'` to set the timezone.
 
 ## Volumes:
 
@@ -24,11 +16,11 @@ Configuration data
 
 ### `/var/log/unifi`
 
-Log Files
+Log files
 
 ### `/var/run/unifi`
 
-Run Information
+Run information
 
 ## Environment Variables:
 
@@ -38,16 +30,46 @@ TimeZone. (i.e America/Chicago)
 
 ## Expose:
 
-### 8080/tcp
+### 8080/tcp - Device command/control
 
-### 8081/tcp
+### 8443/tcp - Web interface + API
 
-### 8443/tcp
+### 8843/tcp - HTTPS portal
 
-### 8843/tcp
+### 8880/tcp - HTTP portal
 
-### 8880/tcp
+### 3478/udp - STUN service
 
-### 3478/udp
+### 6789/tcp - Speed Test (unifi5 only)
 
-### 6789/tcp
+See [UniFi - Ports Used](https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used)
+
+## Mulit-process container
+
+While micro-service patterns try to avoid running multiple processes in a container, the unifi5 container tries to follow the same process execution model intended by the original debian package and it's init script, while trying to avoid needing to run a full init system.
+
+Essentially, `dump-init` runs a simple shell wrapper script placed at `/usr/local/bin/unifi.sh`. `unifi.sh` executes and waits on the jsvc process which orchestrates running the controller as a service. The wrapper script also traps SIGTERM to issue the appropriate stop command to the unifi java `com.ubnt.ace.Launcher` process in the hopes that it helps keep the shutdown graceful.
+
+Example seen within the container after it was started
+
+```bash
+$  docker exec -it ef081fcf6440 bash
+# ps -e -o pid,ppid,cmd | more
+  PID  PPID CMD
+    1     0 /usr/bin/dumb-init -- /usr/local/bin/unifi.sh
+    7     1 sh /usr/local/bin/unifi.sh
+    9     7 unifi -nodetach -home /usr/lib/jvm/java-8-openjdk-amd64 -classpath /usr/share/java/commons-daemon.jar:/usr/lib/unifi/lib/ace.jar -pidfile /var/run/unifi/unifi.pid -procname unifi -outfile /var/log/unifi/unifi.out.log -errfile /var/log/unifi/unifi.err.log -Dunifi.datadir=/var/lib/unifi -Dunifi.rundir=/var/run/unifi -Dunifi.logdir=/var/log/unifi -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xmx1024M -Xms32M com.ubnt.ace.Launcher start
+   10     9 unifi -nodetach -home /usr/lib/jvm/java-8-openjdk-amd64 -classpath /usr/share/java/commons-daemon.jar:/usr/lib/unifi/lib/ace.jar -pidfile /var/run/unifi/unifi.pid -procname unifi -outfile /var/log/unifi/unifi.out.log -errfile /var/log/unifi/unifi.err.log -Dunifi.datadir=/var/lib/unifi -Dunifi.rundir=/var/run/unifi -Dunifi.logdir=/var/log/unifi -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xmx1024M -Xms32M com.ubnt.ace.Launcher start
+   31    10 /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -Xmx1024M -XX:ErrorFile=/usr/lib/unifi/data/logs/hs_err_pid<pid>.log -Dapple.awt.UIElement=true -jar /usr/lib/unifi/lib/ace.jar start
+   58    31 bin/mongod --dbpath /usr/lib/unifi/data/db --port 27117 --logappend --logpath logs/mongod.log --nohttpinterface --bind_ip 127.0.0.1
+  108     0 bash
+  116   108 ps -e -o pid,ppid,cmd
+  117   108 [bash]
+```
+
+## TODO
+
+Future work?
+
+- Don't run as root (but Unifi's Debian package does by the way...)
+- Possibly use Debian image with systemd init included (but thus far, I don't know of an official Debian systemd image to base off)


### PR DESCRIPTION
Fixed missing symlinks for data, log and run dirs. Refactored to use dumb-init, a small wrapper script and jsvc to better match how the original debian package runs the software. Pushed in openjdk headless java-8 and removed external dependany on mongo.org (debain repo version for mongodb was adequet).

Tested as working for me from within a docker container. Logs, etc now using the correct directories. The `RUN ln...` is important.

Some of the other changes conflict with a microservice philosophy with or have added extra processes into the container, but IMO, it might be safer to mimic the way the debian package intends running the controller software (at least until it's clear upstream has refactored the app to work well within docker).