### PR TITLE
Switch to using Docker image debian:jessie-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:jessie
+# FROM debian:jessie-slim
   # WORKING: ends up being 500MB+
 # FROM openjdk:8-jdk
   # openjdk:8-jdk might sound like a good alternative, currently based on debian jessie, but Docker could switch that to apline some day? It's 600MB+!!
-# FROM debian:jessie-slim
-  # NOT WORKING. seems to cause issues when installing openjdk when update-alternatives tries to link a man page and breaks just because man pages are not installed. `--force-all` might work arround it, but that's a hack... :-/
+FROM debian:jessie-slim
+  # WORKING: work around openjdk issue which expects the man-page directory, failing to configure package if it doesn't
 
 MAINTAINER Jacob Alberty <jacob.alberty@foundigital.com>
 
@@ -22,7 +22,8 @@ RUN echo "deb http://deb.debian.org/debian/ jessie-backports main" > /etc/apt/so
   #apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
 
 # Push installing openjdk-8-jre first, so that the unifi package doesn't pull in openjdk-7-jre as a dependency? Else uncomment and just go with openjdk-7.
-RUN apt-get clean && \
+RUN mkdir -p /usr/share/man/man1/ && \
+  apt-get clean && \
   apt-get update && \
   apt-get install -qy --no-install-recommends curl gdebi-core && \
   apt-get install -t jessie-backports -qy --no-install-recommends \
@@ -69,7 +70,7 @@ RUN chmod +x /usr/local/bin/unifi.sh
 
 WORKDIR /var/lib/unifi
 
-# execute controller using JSVC like orignial debian package does
+# execute controller using JSVC like original debian package does
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/usr/local/bin/unifi.sh"]
 


### PR DESCRIPTION
This allows using Docker image debian:jessy-slim by manually creating the man1 directory, working around bug https://bugs.launchpad.net/ubuntu/+source/openjdk-8/+bug/1576019, avoiding having to force the install. 

(oh, yeah, I fixed a typo as well :) )