### PR TITLE
Adds thread stack size parameter for CVE-2017-1000364 issue

### DIFF
--- a/unifi.sh
+++ b/unifi.sh
@@ -9,12 +9,19 @@ JVM_OPTS="
   -Dunifi.logdir=${LOGDIR}
   -Djava.awt.headless=true
   -Dfile.encoding=UTF-8"
+
 if [ ! -z "${JVM_MAX_HEAP_SIZE}" ]; then
-	JVM_OPTS="${JVM_OPTS} -Xmx${JVM_MAX_HEAP_SIZE}"
+  JVM_OPTS="${JVM_OPTS} -Xmx${JVM_MAX_HEAP_SIZE}"
 fi
+
 if [ ! -z "${JVM_INIT_HEAP_SIZE}" ]; then
   JVM_OPTS="${JVM_OPTS} -Xms${JVM_INIT_HEAP_SIZE}"
 fi
+
+if [ ! -z "${JVM_MAX_THREAD_STACK_SIZE}" ]; then
+  JVM_OPTS="${JVM_OPTS} -Xss${JVM_MAX_THREAD_STACK_SIZE}"
+fi
+
 JSVC_OPTS="
   -home ${JAVA_HOME}
   -classpath /usr/share/java/commons-daemon.jar:${BASEDIR}/lib/ace.jar
@@ -23,6 +30,7 @@ JSVC_OPTS="
   -outfile ${LOGDIR}/unifi.out.log
   -errfile ${LOGDIR}/unifi.err.log
   ${JVM_OPTS}"
+
 # One issue might be no cron and lograte, causing the log volume to become bloated over time! Consider `-keepstdin` and `-errfile &2` options for JSVC.
 MAINCLASS='com.ubnt.ace.Launcher'
 


### PR DESCRIPTION
Adds workaround recommended here: https://community.ubnt.com/t5/UniFi-Routing-Switching/IMPORTANT-Debian-Ubuntu-users-MUST-READ-Updated-06-21/m-p/1968251#M48264 for CVE-2017-1000364 issue.

Pass the following in your `docker run` command:

```
--env JVM_MAX_THREAD_STACK_SIZE=1280k
```