### PR TITLE
JSVC_OPTS change to reflect kernel change

### DIFF
--- a/unifi.sh
+++ b/unifi.sh
@@ -16,6 +16,7 @@ if [ ! -z "${JVM_INIT_HEAP_SIZE}" ]; then
   JVM_OPTS="${JVM_OPTS} -Xms${JVM_INIT_HEAP_SIZE}"
 fi
 JSVC_OPTS="
+  -Xss1280k
   -home ${JAVA_HOME}
   -classpath /usr/share/java/commons-daemon.jar:${BASEDIR}/lib/ace.jar
   -pidfile ${PIDFILE}


### PR DESCRIPTION
Unifi wouldn't start without this JSCV_OPTS line that I added.

Reference: https://community.ubnt.com/t5/UniFi-Routing-Switching/IMPORTANT-Debian-Ubuntu-users-MUST-READ-Updated-06-21/m-p/1968251#M48264