### PR TITLE
Update Dockerfile to support 5.5.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Jacob Alberty <jacob.alberty@foundigital.com>
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ENV PKGURL=https://dl.ubnt.com/unifi/5.4.19/unifi_sysvinit_all.deb
+ENV PKGURL=https://dl.ubnt.com/unifi/5.5.20/unifi_sysvinit_all.deb
 
 # Need backports for openjdk-8
 RUN echo "deb http://deb.debian.org/debian/ jessie-backports main" > /etc/apt/sources.list.d/10backports.list && \


### PR DESCRIPTION
A few hours ago version 5.5.20 was released. I changed the controller to version 5.5.20, tested and ran it. Also verified it was ran and upgraded the database of version 5.4.19.