### PR TITLE
Support custom controller UI/API port for HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN mkdir -p /usr/unifi \
      /usr/local/unifi/init.d \
      /usr/unifi/init.d
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-healthcheck.sh /usr/local/bin/
 COPY functions /usr/unifi/functions
 COPY import_cert /usr/unifi/init.d/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
@@ -52,7 +53,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
 
 WORKDIR /var/lib/unifi
 
-HEALTHCHECK CMD curl -k -L --fail https://localhost:8443 || exit 1
+HEALTHCHECK CMD /usr/local/bin/docker-healthcheck.sh || exit 1
 
 # execute controller using JSVC like original debian package does
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+SYSPROPS_FILE=${DATADIR}/system.properties
+SYSPROPS_PORT=`grep "^unifi.https.port=" ${SYSPROPS_FILE} | cut -d'=' -f2`
+PORT=${SYSPROPS_PORT:-8443}
+
+curl -k -L --fail https://localhost:${PORT}


### PR DESCRIPTION
The HEALTHCHECK command hard-codes the default controller UI/API port.
This fails (shows the container status as unhealthy) if the user has
specified a custom port for it in the system properties file.

Make this work correctly in such cases by parsing the port from the file
if it is present and uncommented. In order to avoid a stupidly
complicated one-liner move the healthcheck command into a separate shell
script.