### PR TITLE
Set curl to follow redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN mkdir -p /usr/share/man/man1/ \
     libcap2-bin \
  && echo "deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti" > /etc/apt/sources.list.d/20ubiquiti.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv C0A52C50 \
- && curl -o ./unifi.deb "${PKGURL}" \
+ && curl -L -o ./unifi.deb "${PKGURL}" \
  && apt -qy install ./unifi.deb \
  && apt-get -qy purge --auto-remove \
     dirmngr \


### PR DESCRIPTION
URLs provided by Ubiquiti sometimes are redirects to the actual hosted files for their packages, this change allows you to specify that initial URL as the PKG_URL parameter. Otherwise, it will fail to download the actual .deb file unless you resolve the final URL yourself before providing it to the docker build command.