### PR TITLE
Update to 5.7.15-sc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Jacob Alberty <jacob.alberty@foundigital.com>
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ENV PKGURL=https://dl.ubnt.com/unifi/5.6.29-445c8ce6c7/unifi_sysvinit_all.deb
+ENV PKGURL=https://dl.ubnt.com/unifi/5.7.15-e9b882be05/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is suggested you start running this as a non root user. The default right now
 
 | Version | Latest Tag |
 |---------|------------|
-| 5.6.x   | [`5.6.29-sc`](https://github.com/jacobalberty/unifi-docker/blob/5.6.29-sc/Dockerfile) |
+| 5.7.x   | [`5.7.15-sc`](https://github.com/jacobalberty/unifi-docker/blob/5.7.15-sc/Dockerfile) |
 
 These tags generally track the UniFi APT repository. We do lead the repository a little when it comes to pushing the latest version. The latest version gets pushed when it moves from `stable candidate` to `stable` instead of waiting for it to hit the repository.
 


### PR DESCRIPTION
Version 5.7 is now a stable candidate ( https://help.ubnt.com/hc/en-us/articles/115000441548-UniFi-Current-Controller-Versions ).

People should have the possibility to update to that release new release.