### PR TITLE
Change into $BASEDIR before starting controller to fix relative paths

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -115,6 +115,9 @@ for key in "${!settings[@]}"; do
 done
 UNIFI_CMD="java ${JVM_OPTS} -jar ${BASEDIR}/lib/ace.jar start"
 
+# controller writes to relative path logs/server.log
+cd ${BASEDIR}
+
 CUID=$(id -u)
 
 if [[ "${@}" == "unifi" ]]; then


### PR DESCRIPTION
Commit https://github.com/jacobalberty/unifi-docker/commit/be3659b33f8c64f5dd5c9a4c6660c05018230f6f removed `JVM_EXTRA_OPTS="-cwd /usr/lib/unifi"`, so the controller was no longer running from the `$BASEDIR`.

The server is writing the log file into a relative path at `logs/server.log` which now becomes relative to the root directory. When `RUNAS_UID0=false` then the server has no longer write access and cannot write the log file at all.