### PR TITLE
Rewrite docker-compose.yml in v2.2 format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,54 +1,42 @@
-version: '2.4'
+version: '2.2'
 services:
   mongo:
     image: mongo:3.4
     networks:
-    - unifi
+      - unifi
     restart: always
     volumes:
-    - type: volume
-      source: db
-      target: /data/db
+      - db:/data/db
   controller:
     image: "jacobalberty/unifi:${TAG:-latest}"
     depends_on:
-    - mongo
+      - mongo
     init: true
     networks:
-    - unifi
+      - unifi
     restart: always
     volumes:
-    - type: volume
-      source: data
-      target: /unifi/data
-    - type: volume
-      source: log
-      target: /unifi/log
-    - type: volume
-      source: cert
-      target: /unifi/cert
-    - type: volume
-      source: init
-      target: /unifi/init.d
+      - data:/unifi/data
+      - log:/unifi/log
+      - cert:/unifi/cert
+      - init:/unifi/init.d
     environment:
       DB_URI: mongodb://mongo/unifi
       STATDB_URI: mongodb://mongo/unifi_stat
       DB_NAME: unifi
     ports:
-    - "8080:8080"
-    - "8443:8443"
-    - "3478:3478/udp"
-    - "10001:10001/udp"
+      - "8080:8080"
+      - "8443:8443"
+      - "3478:3478/udp"
+      - "10001:10001/udp"
   logs:
     image: bash
     depends_on:
-    - controller
+      - controller
     command: bash -c 'tail -f /unifi/log/*'
     restart: always
     volumes:
-    - type: volume
-      source: log
-      target: /unifi/log
+      - log:/unifi/log
 
 volumes:
   db:


### PR DESCRIPTION
v2.2 is more widely supported than 2.4 (e.g. CentOS/RHEL)