### PR TITLE
Add time out to health check curl command

### DIFF
--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -6,4 +6,4 @@ if [ -f "${SYSPROPS_FILE}" ]; then
 fi
 PORT=${SYSPROPS_PORT:-8443}
 
-curl -kILs --fail https://localhost:${PORT}
+curl --max-time 5 -kILs --fail https://localhost:${PORT}


### PR DESCRIPTION
If you run this container on docker for windows and mount the mongo files as a local volumne, [mongo will crash because it can't fsync the data files](https://github.com/docker/for-win/issues/138).

For whatever reason this causes the curl command to hang forever and the container will eat all your CPU.