### PR TITLE
Expose ALL appropriate ports +  RUNAS_UID0 for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,15 @@ services:
       DB_URI: mongodb://mongo/unifi
       STATDB_URI: mongodb://mongo/unifi_stat
       DB_NAME: unifi
+      RUNAS_UID0: "false"
     ports:
-      - "8080:8080"
-      - "8880:8880"
-      - "8443:8443"
-      - "3478:3478/udp"
-      - "10001:10001/udp"
+      - "3478:3478/udp" # STUN
+      - "6789:6789/tcp" # Speed test
+      - "8080:8080/tcp" # Device/ controller comm.
+      - "8443:8443/tcp" # Controller GUI/API as seen in a web browser
+      - "8880:8880/tcp" # HTTP portal redirection
+      - "8843:8843/tcp" # HTTPS portal redirection
+      - "10001:10001/udp" # AP discovery
   logs:
     image: bash
     depends_on:


### PR DESCRIPTION
Ports exposed is now consistent, more comprehensive and documented with comments.
Also no reason to not have `RUNAS_UID0=false` in a docker-compose environment.