### PR TITLE
Update ubuntu, add required depends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ RUN set -ex \
     && chmod +x /usr/unifi/init.d/import_cert \
     && chmod +x /usr/local/bin/docker-healthcheck.sh \
     && chmod +x /usr/local/bin/docker-build.sh \
-    && apt-get install -y --no-install-recommends openjdk-8-jre-headless \
     && mkdir -p /usr/share/man/man1/ \
     && groupadd -r unifi -g $UNIFI_GID \
     && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex \
     && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \
     && /usr/local/bin/docker-build.sh "${PKGURL}" \
     && apt-get purge -y --auto-remove wget \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 VOLUME ["/unifi", "${RUNDIR}"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex \
     && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
-    ##### verify the signature
+    # verify the signature
     && export GNUPGHOME="$(mktemp -d)" \
     && for server in $(shuf -e ha.pool.sks-keyservers.net \
                             hkp://p80.pool.sks-keyservers.net:80 \
@@ -48,10 +48,9 @@ RUN set -ex \
         gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
     done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    ##### end verify
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
-    ##### verify that the binary works
+    # verify that the binary works
     && gosu nobody true \
     && apt-get purge -y --auto-remove $fetchDeps \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY import_cert /usr/unifi/init.d/
 # Install Gosu
 RUN set -ex \
     && apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates gnupg wget \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg wget gosu \
 # Install Unifi
     && chmod +x /usr/local/bin/docker-entrypoint.sh \
     && chmod +x /usr/unifi/init.d/import_cert \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL
+ENV PKGURL=https://dl.ubnt.com/unifi/5.10.20/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \
@@ -25,18 +25,20 @@ ENV BASEDIR=/usr/lib/unifi \
 # Install gosu
 # https://github.com/tianon/gosu/blob/master/INSTALL.md
 # This should be integrated with the main run because it duplicates a lot of the steps there
-# but for now while shoehorning gosu in it is seperate
+# but for now while shoehorning gosu in it is separate
 RUN set -ex \
     && fetchDeps=' \
         ca-certificates \
         wget \
+        gpg \
+        dirmngr \
     ' \
     && apt-get update \
     && apt-get install -y --no-install-recommends $fetchDeps \
     && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
-# verify the signature
+    ##### verify the signature
     && export GNUPGHOME="$(mktemp -d)" \
     && for server in $(shuf -e ha.pool.sks-keyservers.net \
                             hkp://p80.pool.sks-keyservers.net:80 \
@@ -46,9 +48,10 @@ RUN set -ex \
         gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
     done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    ##### end verify
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
-# verify that the binary works
+    ##### verify that the binary works
     && gosu nobody true \
     && apt-get purge -y --auto-remove $fetchDeps \
     && rm -rf /var/lib/apt/lists/*
@@ -66,8 +69,8 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
  && chmod +x /usr/local/bin/docker-healthcheck.sh \
  && chmod +x /usr/local/bin/docker-build.sh
 
-# Push installing openjdk-8-jre first, so that the unifi package doesn't pull in openjdk-7-jre as a dependency? Else uncomment and just go with openjdk-7.
 RUN set -ex \
+ && apt-get update && apt-get install -y --no-install-recommends gnupg \
  && mkdir -p /usr/share/man/man1/ \
  && groupadd -r unifi -g $UNIFI_GID \
  && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \
@@ -81,12 +84,12 @@ WORKDIR /unifi
 
 HEALTHCHECK CMD /usr/local/bin/docker-healthcheck.sh || exit 1
 
-# execute controller using JSVC like original debian package does
+# execute controller using JSVC like original Debian package does
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 CMD ["unifi"]
 
-# execute the conroller directly without using the service
+# execute the controller directly without using the service
 #ENTRYPOINT ["/usr/bin/java", "-Xmx${JVM_MAX_HEAP_SIZE}", "-jar", "/usr/lib/unifi/lib/ace.jar"]
-  # See issue #12 on github: probably want to consider how JSVC handled creating multiple processes, issuing the -stop instraction, etc. Not sure if the above ace.jar class gracefully handles TERM signals.
+  # See issue #12 on github: probably want to consider how JSVC handled creating multiple processes, issuing the -stop instruction, etc. Not sure if the above ace.jar class gracefully handles TERM signals.
 #CMD ["start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,6 @@ RUN set -ex \
     && chmod +x /usr/unifi/init.d/import_cert \
     && chmod +x /usr/local/bin/docker-healthcheck.sh \
     && chmod +x /usr/local/bin/docker-build.sh \
-    && apt-get install -y --no-install-recommends openjdk-8-jre-headless \
     && mkdir -p /usr/share/man/man1/ \
     && groupadd -r unifi -g $UNIFI_GID \
     && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ ENV BASEDIR=/usr/lib/unifi \
     CERTNAME=cert.pem \
     CERT_PRIVATE_NAME=privkey.pem \
     CERT_IS_CHAIN=false \
-    GOSU_VERSION=1.10 \
     BIND_PRIV=true \
     RUNAS_UID0=true \
     UNIFI_GID=999 \
@@ -36,30 +35,13 @@ COPY import_cert /usr/unifi/init.d/
 # Install Gosu
 RUN set -ex \
     && apt-get update \
-    && apt-get dist-upgrade -y \
-    && apt-get install -y --no-install-recommends ca-certificates gnupg wget \
-    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
-    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
-    # verify the signature
-    && export GNUPGHOME="$(mktemp -d)" \
-    && for server in $(shuf -e ha.pool.sks-keyservers.net \
-                            hkp://p80.pool.sks-keyservers.net:80 \
-                            keyserver.ubuntu.com \
-                            hkp://keyserver.ubuntu.com:80 \
-                            pgp.mit.edu) ; do \
-        gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
-    done \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # verify that the binary works
-    && gosu nobody true \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg wget gosu \
 # Install Unifi
     && chmod +x /usr/local/bin/docker-entrypoint.sh \
     && chmod +x /usr/unifi/init.d/import_cert \
     && chmod +x /usr/local/bin/docker-healthcheck.sh \
     && chmod +x /usr/local/bin/docker-build.sh \
+    && apt-get install -y --no-install-recommends openjdk-8-jre-headless \
     && mkdir -p /usr/share/man/man1/ \
     && groupadd -r unifi -g $UNIFI_GID \
     && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ ENV BASEDIR=/usr/lib/unifi \
     BIND_PRIV=true \
     RUNAS_UID0=true \
     UNIFI_GID=999 \
-    UNIFI_UID=999
+    UNIFI_UID=999 \
+    JVM_MAX_HEAP_SIZE=1024M
 
 # Install gosu
 # https://github.com/tianon/gosu/blob/master/INSTALL.md
@@ -30,8 +31,7 @@ RUN set -ex \
     && fetchDeps=' \
         ca-certificates \
         wget \
-        gpg \
-        dirmngr \
+        gnupg \
     ' \
     && apt-get update \
     && apt-get install -y --no-install-recommends $fetchDeps \
@@ -69,7 +69,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
  && chmod +x /usr/local/bin/docker-build.sh
 
 RUN set -ex \
- && apt-get update && apt-get install -y --no-install-recommends gnupg \
+ && apt-get update && apt-get install -y --no-install-recommends gnupg openjdk-8-jre-headless \
  && mkdir -p /usr/share/man/man1/ \
  && groupadd -r unifi -g $UNIFI_GID \
  && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
@@ -20,8 +20,7 @@ ENV BASEDIR=/usr/lib/unifi \
     RUNAS_UID0=true \
     UNIFI_GID=999 \
     UNIFI_UID=999 \
-    JVM_MAX_HEAP_SIZE=1024M \
-    GOSU_VERSION=1.10
+    JVM_MAX_HEAP_SIZE=1024M
 
 # Copy install and runtime scripts
 RUN mkdir -p /usr/unifi \
@@ -37,23 +36,6 @@ COPY import_cert /usr/unifi/init.d/
 RUN set -ex \
     && apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg wget \
-    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
-    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
-    # verify the signature
-    && export GNUPGHOME="$(mktemp -d)" \
-    && for server in $(shuf -e ha.pool.sks-keyservers.net \
-                            hkp://p80.pool.sks-keyservers.net:80 \
-                            keyserver.ubuntu.com \
-                            hkp://keyserver.ubuntu.com:80 \
-                            pgp.mit.edu) ; do \
-    gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
-    done \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # verify that the binary works
-    && gosu nobody true \
 # Install Unifi
     && chmod +x /usr/local/bin/docker-entrypoint.sh \
     && chmod +x /usr/unifi/init.d/import_cert \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:xenial
 
 LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
@@ -20,7 +20,8 @@ ENV BASEDIR=/usr/lib/unifi \
     RUNAS_UID0=true \
     UNIFI_GID=999 \
     UNIFI_UID=999 \
-    JVM_MAX_HEAP_SIZE=1024M
+    JVM_MAX_HEAP_SIZE=1024M \
+    GOSU_VERSION=1.10
 
 # Copy install and runtime scripts
 RUN mkdir -p /usr/unifi \
@@ -35,7 +36,24 @@ COPY import_cert /usr/unifi/init.d/
 # Install Gosu
 RUN set -ex \
     && apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates gnupg wget gosu \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg wget \
+    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
+    # verify the signature
+    && export GNUPGHOME="$(mktemp -d)" \
+    && for server in $(shuf -e ha.pool.sks-keyservers.net \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            pgp.mit.edu) ; do \
+    gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+    done \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    # verify that the binary works
+    && gosu nobody true \
 # Install Unifi
     && chmod +x /usr/local/bin/docker-entrypoint.sh \
     && chmod +x /usr/unifi/init.d/import_cert \


### PR DESCRIPTION
Update Ubuntu base to 18.04 bionic, add required depends for ```docker build``` to complete. Also added openJDK 8 and set JVM head size via ENV.

Tested on arm64 / raspberry pi 3b+