### PR TITLE
Changed pgp store to pool.sks-keyservers.net

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex \
                             hkp://p80.pool.sks-keyservers.net:80 \
                             keyserver.ubuntu.com \
                             hkp://keyserver.ubuntu.com:80 \
-                            pgp.mit.edu) ; do \
+                            pool.sks-keyservers.net) ; do \
         gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
     done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \


### PR DESCRIPTION
The Docker image fails to load, hanging on a response from pgp.mit.edu. Changed to use pool.sks-keyservers.net and everything continues to work splendidly.