### PR TITLE
Added socat into distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN set -ex \
     ' \
     && apt-get update \
     && apt-get install -y --no-install-recommends $fetchDeps \
+    && apt-get install -y socat \ 
     && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \


### PR DESCRIPTION
I would like to set up port redirection for problematic site that has port 8080 blocked by upstream. So I think adding socat is reasonable to resolve the issue since it increases image size only by 5 MB. 