### PR TITLE
add post configure script hook into docker-entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -130,6 +130,12 @@ fi
 for key in "${!settings[@]}"; do
   confSet "$confFile" "$key" "${settings[$key]}"
 done
+
+if [ -n "${UNIFI_POST_CONFIGURE_SCRIPT+x}" ]; then
+  echo "Running Post Configure Script..."
+  eval "${UNIFI_POST_CONFIGURE_SCRIPT}"
+fi
+
 UNIFI_CMD="java ${JVM_OPTS} -jar ${BASEDIR}/lib/ace.jar start"
 
 # controller writes to relative path logs/server.log


### PR DESCRIPTION
Make it possible to execute custom code when starting the container.

For example you can run a script to edit the port in `system.properties` before the first start of the container.