### PR TITLE
Move backup folder locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       - log:/unifi/log
       - cert:/unifi/cert
       - init:/unifi/init.d
-      # Uncomment following line to have backups stored in a local folder
-      # ./backup/:/unifi/data/backup/
+      # Uncomment the following mount to store backups in a local folder
+      #- ./backup:/unifi/data/backup
     environment:
       DB_URI: mongodb://mongo/unifi
       STATDB_URI: mongodb://mongo/unifi_stat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
       - cert:/unifi/cert
       - init:/unifi/init.d
       - run:/var/run/unifi
-      # Uncomment the following mount to store backups in a local folder
-      #- ./backup:/unifi/data/backup
+      # Mount local folder for backups and autobackups
+      - ./backup:/unifi/data/backup
     environment:
       DB_URI: mongodb://mongo/unifi
       STATDB_URI: mongodb://mongo/unifi_stat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - log:/unifi/log
       - cert:/unifi/cert
       - init:/unifi/init.d
+      ./backup/:/unifi/data/backup/
     environment:
       DB_URI: mongodb://mongo/unifi
       STATDB_URI: mongodb://mongo/unifi_stat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       - log:/unifi/log
       - cert:/unifi/cert
       - init:/unifi/init.d
-      ./backup/:/unifi/data/backup/
+      # Uncomment following line to have backups stored in a local folder
+      # ./backup/:/unifi/data/backup/
     environment:
       DB_URI: mongodb://mongo/unifi
       STATDB_URI: mongodb://mongo/unifi_stat


### PR DESCRIPTION
Hey guys,
I would argue that it's a meaningful default to mount the backup (and therefore autobackup) folder from a local subfolder. These files are clearly of exchange nature for the emergency case and hence should be bundled with `docker-compose.yml`.

Happy to revert to a comment or a mentioning of this option in the README.

Wdyt? 