### PR TITLE
Replace short key ID with long key ID

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -40,7 +40,7 @@ tryfail apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F373035
 echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 apt-get update
 echo "deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti" > /etc/apt/sources.list.d/20ubiquiti.list
-tryfail apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv C0A52C50
+tryfail apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 06E85760C0A52C50
 curl -L -o ./unifi.deb "${1}"
 apt -qy install mongodb-org ./unifi.deb
 rm -f ./unifi.deb


### PR DESCRIPTION
As discussed [here](https://security.stackexchange.com/questions/74009/what-is-an-openpgp-key-id-collision/74010#74010), a short key ID is more susceptible to a collision than a long key ID.

This PR replaces the short key ID with the long key ID (found on [this page](https://help.ubnt.com/hc/en-us/articles/220066768-UniFi-How-to-Install-Update-via-APT-on-Debian-or-Ubuntu#STEPS))