### PR TITLE
Addition of docker-compose environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=unifi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME}_logs
     depends_on:
       - controller
-    command: bash -c 'tail -f /unifi/log/*.log'
+    command: bash -c 'tail -F /unifi/log/*.log'
     restart: always
     volumes:
       - log:/unifi/log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.2'
 services:
   mongo:
     image: mongo:3.4
+    container_name: ${COMPOSE_PROJECT_NAME}_mongo
     networks:
       - unifi
     restart: always
@@ -9,6 +10,7 @@ services:
       - db:/data/db
   controller:
     image: "jacobalberty/unifi:${TAG:-latest}"
+    container_name: ${COMPOSE_PROJECT_NAME}_controller
     depends_on:
       - mongo
     init: true
@@ -34,6 +36,7 @@ services:
       - "10001:10001/udp" # AP discovery
   logs:
     image: bash
+    container_name: ${COMPOSE_PROJECT_NAME}_logs
     depends_on:
       - controller
     command: bash -c 'tail -f /unifi/log/*.log'


### PR DESCRIPTION
Adds the "unifi" prefix to container names to make them more visible and sorted in deployments with a large number of running containers.

Also a small change to TAIL(1) in the logs container.