### PR TITLE
Use PKCS keystore

### DIFF
--- a/import_cert
+++ b/import_cert
@@ -84,6 +84,7 @@ _EOF
         -deststorepass aircontrolenterprise \
         -destkeypass aircontrolenterprise \
         -destkeystore "${DATADIR}/keystore" \
+        -deststoretype pkcs12 \
         -srckeystore "${TEMPFILE}" -srcstoretype PKCS12 \
         -srcstorepass aircontrolenterprise \
         -alias unifi

--- a/import_cert
+++ b/import_cert
@@ -72,7 +72,7 @@ _EOF
     else
         awk 1 "${CERTDIR}/chain.pem" "${CERTDIR}/${CERTNAME}" >> "${CHAIN}"
     fi
-   openssl pkcs12 -export  -passout pass:aircontrolenterprise \
+   openssl pkcs12 -export -passout pass:aircontrolenterprise \
         -in "${CHAIN}" \
         -inkey "${CERTDIR}/${CERT_PRIVATE_NAME}" \
         -out "${TEMPFILE}" -name unifi
@@ -83,9 +83,8 @@ _EOF
     keytool -trustcacerts -importkeystore \
         -deststorepass aircontrolenterprise \
         -destkeypass aircontrolenterprise \
-        -destkeystore "${DATADIR}/keystore" \
-        -deststoretype pkcs12 \
-        -srckeystore "${TEMPFILE}" -srcstoretype PKCS12 \
+        -destkeystore "${DATADIR}/keystore" -deststoretype pkcs12 \
+        -srckeystore "${TEMPFILE}" -srcstoretype pkcs12 \
         -srcstorepass aircontrolenterprise \
         -alias unifi
     log "Cleaning up temp files"


### PR DESCRIPTION
Hey guys,
this should solve the error shown below:

```
controller_1  | 2019-11-27T21:11:05.858677594Z [2019-11-27 21:11:05,819] <docker-entrypoint> Cert directory found. Checking Certs
controller_1  | 2019-11-27T21:11:06.432834438Z [2019-11-27 21:11:06,432] <docker-entrypoint> Cert has changed, updating controller...
controller_1  | 2019-11-27T21:11:06.434731343Z [2019-11-27 21:11:06,434] <docker-entrypoint> Using openssl to prepare certificate...
controller_1  | 2019-11-27T21:11:06.603285326Z [2019-11-27 21:11:06,602] <docker-entrypoint> Removing existing certificate from Unifi protected keystore...
controller_1  | 2019-11-27T21:11:08.826170553Z [2019-11-27 21:11:08,825] <docker-entrypoint> Inserting certificate into Unifi keystore...
controller_1  | 2019-11-27T21:11:08.926819788Z Importing keystore /tmp/tmp.IS1Wqrg8a9 to /unifi/data/keystore...
controller_1  | 2019-11-27T21:11:09.428676949Z
controller_1  | 2019-11-27T21:11:09.428718931Z Warning:
controller_1  | 2019-11-27T21:11:09.428726783Z The JKS keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using "keytool -importkeystore -srckeystore /unifi/data/keystore -destkeystore /unifi/data/keystore -deststoretype pkcs12".
controller_1  | 2019-11-27T21:11:09.443492916Z [2019-11-27 21:11:09,443] <docker-entrypoint> Cleaning up temp files
controller_1  | 2019-11-27T21:11:09.446154375Z [2019-11-27 21:11:09,445] <docker-entrypoint> Done!
controller_1  | 2019-11-27T21:11:09.584980579Z [2019-11-27 21:11:09,584] <docker-entrypoint> Starting unifi controller service.
```

Sorry, I did NOT test the change. Please check if it's all it takes

Edit: Judging by forum entries this might not be as easy as it seems. Please close PR if that's the case.
