### PR TITLE
Add DNS to make sure firmware upgrade path to url.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     networks:
       - unifi
     restart: always
+    dns:
+      - 8.8.8.8
+      - 4.4.4.4
     volumes:
       - data:/unifi/data
       - log:/unifi/log


### PR DESCRIPTION
Controller have no correct dns to firmware url to ubiquiti office firmware download location. This will cause auto firmware detection failure.