### PR TITLE
Pass --quiet and --nojournal if LOTSOFDEVICES is set.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -115,6 +115,9 @@ if ! [[ -z "$LOTSOFDEVICES" ]]; then
   settings["unifi.G1GC.enabled"]="true"
   settings["unifi.xms"]="$(h2mb $JVM_INIT_HEAP_SIZE)"
   settings["unifi.xmx"]="$(h2mb ${JVM_MAX_HEAP_SIZE:-1024M})"
+  # Reduce MongoDB I/O (issue #300)
+  settings["unifi.db.nojournal"]="true"
+  settings["unifi.db.extraargs"]="--quiet"
 fi
 
 # Implements issue #30


### PR DESCRIPTION
These flags seem to help with high I/O from Mongo as observed in issue #300.