### PR TITLE
Update docker-build.sh

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -45,6 +45,7 @@ apt-get update
 echo "deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti" > /etc/apt/sources.list.d/20ubiquiti.list
 tryfail apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 06E85760C0A52C50
 curl -L -o ./unifi.deb "${1}"
+debconf-set-selections <<< "debconf debconf/frontend select Noninteractive"
 apt -qy install mongodb-org ./unifi.deb
 rm -f ./unifi.deb
 chown -R unifi:unifi /usr/lib/unifi


### PR DESCRIPTION
pulling the beta tag of the unifi docker image (jacobalberty/unifi:beta) makes the mongo db install ignore or do not use the TZ env variable when deploying the container. 
This is resulting into the deployment of the beta container to stall when the mongodb installation is waiting for an input of TZ data.

