### PR TITLE
Allow unifi controller to pipe logs to stdOut

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ Default: `8443`
 
 This is the HTTPS port used by the Web interface.
 
+### `UNIFI_STDOUT`
+
+Default: `unset`
+
+Controller outputs logs to stdout in addition to server.log
+
 ### `TZ`
 
 TimeZone. (i.e America/Chicago)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -141,6 +141,10 @@ if [[ "$UNIFI_ECC_CERT" == "true" ]]; then
   settings["unifi.https.ciphers"]="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
 fi
 
+if [[ "$UNIFI_STDOUT" == "true" ]]; then
+  settings["unifi.logStdout"]="true"
+fi
+
 for key in "${!settings[@]}"; do
   confSet "$confFile" "$key" "${settings[$key]}"
 done


### PR DESCRIPTION
This allows the unifi controller to pipe it's logs to stdout without a helper shell to do that for us. I know this doesn't cover mongo (not sure if there's anything one can do about that), but for those of us using an external mongo it's helpfull

I'd actually be partial for this to be the default, but I'd like to hear what everyone else thinks