### PR TITLE
Write properties file after creating ${DATADIR}

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -145,9 +145,6 @@ if [[ "$UNIFI_STDOUT" == "true" ]]; then
   settings["unifi.logStdout"]="true"
 fi
 
-for key in "${!settings[@]}"; do
-  confSet "$confFile" "$key" "${settings[$key]}"
-done
 UNIFI_CMD="java ${JVM_OPTS} -jar ${BASEDIR}/lib/ace.jar start"
 
 # controller writes to relative path logs/server.log
@@ -165,6 +162,9 @@ if [[ "${@}" == "unifi" ]]; then
             fi
             mkdir -p "${dir}"
         fi
+    done
+    for key in "${!settings[@]}"; do
+      confSet "$confFile" "$key" "${settings[$key]}"
     done
     if [ "${RUNAS_UID0}" == "true" ] || [ "${CUID}" != "0" ]; then
         if [ "${CUID}" == 0 ]; then


### PR DESCRIPTION
Create the `system.properties` file after creating the missing `${DATADIR}` directory. This file will only be created now if the argument to the script is `unifi`, but that seems appropriate as the properties file is only needed when starting the controller.

The first run of `docker-entrypoint.sh` on an empty unifi volume will fail to create the `system.properties` file as the `data` directory (`${DATADIR}`) on that volume is not created until after it tries to write the `system.properties` file.

Issue: https://github.com/jacobalberty/unifi-docker/issues/401