### PR TITLE
[BUGFIX] Added 10001/udp to allow UniFi Controller device adoption

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN chmod +x /usr/local/unifi/hotfixes/* && run-parts /usr/local/unifi/hotfixes
 
 VOLUME ["/unifi", "${RUNDIR}"]
 
-EXPOSE 6789/tcp 8080/tcp 8443/tcp 8880/tcp 8843/tcp 3478/udp
+EXPOSE 6789/tcp 8080/tcp 8443/tcp 8880/tcp 8843/tcp 3478/udp 10001/udp
 
 WORKDIR /unifi
 


### PR DESCRIPTION
## Description
Added the forever-missing 10001/udp to exposed ports as that is required by UniFi Controller to allow device adoption.  Port 10001 is also required to be opened on the Synology firewall.

## Motivation and Context
Required for UniFi Controller to allow device adoption.

## How Has This Been Tested?
Doesn't work without it.  Does work with it.

## Closing issues
closes #421

## Checklist:
- [X ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
