### PR TITLE
[DOC] Fix wrong year in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You will not be able to bind to lower ports by default. If you also pass the doc
 
 | Tag | Description |
 |-----|-------------|
-| [`latest`, `v7`, `v7.0`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Tracks UniFi stable version - 7.0.25 as of 2021-03-30 [Change Log 7.0.25](https://community.ui.com/releases/UniFi-Network-Application-7-0-25/3344c362-7da5-4ecd-a403-3b47520e3c01)|
+| [`latest`, `v7`, `v7.0`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Tracks UniFi stable version - 7.0.25 as of 2022-03-30 [Change Log 7.0.25](https://community.ui.com/releases/UniFi-Network-Application-7-0-25/3344c362-7da5-4ecd-a403-3b47520e3c01)|
 
 ### Latest Release Candidate tags
 


### PR DESCRIPTION
## Description
Fix the wrong year being referenced in the README. I'm assuming the 2021 should actually be 2022.

## Motivation and Context
Fixing a typo in the README.

## How Has This Been Tested?
The markdown preview still looks good ✅ 

## Closing issues
No issue, but I can create one if needed. 

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
