### PR TITLE
Last pass over README before PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repo contains a Dockerized version of [Ubiqiti Network's](https://www.ubnt.com/) Unifi Controller.
 
 **Why bother?** Using Docker, you can stop worrying about version
-hassles with Unifi Controller, Java, _and_ your OS.
+hassles and update notices for
+Unifi Controller, Java, _or_ your OS.
 A Docker container wraps everything into one well-tested bundle.
 
 To install, a couple lines on the command-line starts the container.
@@ -31,8 +32,8 @@ and start the Docker container running.
 
 ### Setting up directories
 
-One-time setup: create the "unifi" directory on the Docker host.
-Within the "unifi" directory, create two sub-directories: "data" and "log".
+_One-time setup:_ create the `unifi` directory on the Docker host.
+Within that directory, create two sub-directories: `data` and `log`.
 
 ```bash
 cd # by default, use the home directory
@@ -152,7 +153,14 @@ For Unifi-in-Docker, this uses the most recent stable version.
 | [`stable6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
 | [`stable5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |
 
-## Adopting Access Points/Switches/Security Gateway
+### multiarch
+
+All available containers now support multiarch with `amd64`, `armhf`, and `arm64` builds included.
+`armhf` for now uses mongodb 3.4, I do not see much of a path forward for `armhf` due
+to the lack of mongodb support for 32 bit arm, but I will
+support it as long as feasibly possible, for now that date seems to be expiration of support for ubuntu 18.04.
+
+## Adopting Access Points and Unifi Devices
 
 #### Override "Inform Host" IP
 
@@ -169,51 +177,9 @@ To do this:
 * Save settings in Unifi Controller
 * Restart UniFi-in-Docker container with `docker stop ...` and `docker run ...` commands.
 
-## Other Techniques for Adoption
-
-The following are not strictly required for Unifi-in-Docker, but they collect information that may be helpful as you move to a new controller instance.
-
-### Use Unifi export and migrate tool
-
-Unifi can export and migrate the APs to a new controller [see this article for example.](https://lazyadmin.nl/home-network/migrate-unifi-controller/) 
-
-#### SSH Adoption
-
-SSH into the device:
-```
-set-inform http://<docker-host-ip>:8080/inform
-```
-
-#### Force Migration
-
-Force an AP to migrate using [this Unifi community article.](https://community.ui.com/questions/Migrating-UNIFI-APs-to-new-controller/9ca9d8e9-780d-404d-84df-e7762cb810fd)
-
-#### Older versions of Unifi Controller
-
-Older Unifi Controllers use a different name for the "Override Inform Host option".
-Look for **Settings -> Controller:**
-Enter the IP address of the Docker host machine in "Controller Hostname/IP",
-and check the "Override inform host with controller hostname/IP". 
-
-#### Other Options
-
-You can see more options on the [UniFi website](https://help.ubnt.com/hc/en-us/articles/204909754-UniFi-Layer-3-methods-for-UAP-adoption-and-management)
-
-### Layer 2 Adoption
-
-The layer 3 techniques above should be all you need to get new APs to adopt your controller running in Docker.
-You can also configure the Docker instance so that its IP address matches its host address so that Layer 2 adoption works
-using either of these settings.
-
-#### Host Networking
-
-If you launch the container using host networking \(With the `--net=host` parameter on `docker run`\) Layer 2 adoption works as if the controller is installed on the host.
-
-#### Bridge Networking
-
-It is possible to configure the `macvlan` driver to bridge your container to the host's networking adapter.
-Specific instructions for this container are not yet available but you can read a write-up for docker at
-[collabnix.com/docker-17-06-swarm-mode-now-with-macvlan-support](http://collabnix.com/docker-17-06-swarm-mode-now-with-macvlan-support/).
+See [Side Projects](./Side-Projects.md#other-techniques-for-adoption) for
+other techniques to get Unifi devices to adopt your
+new Unifi Controller.
 
 ## Volumes
 
@@ -251,23 +217,23 @@ Other environment variables:
 
 * `UNIFI_HTTP_PORT`
 This is the HTTP port used by the Web interface. Browsers will be redirected to the `UNIFI_HTTPS_PORT`.
-**Default:** `8080`
+**Default: 8080**
 
 * `UNIFI_HTTPS_PORT`
 This is the HTTPS port used by the Web interface.
-**Default:** `8443`
+**Default: 8443** 
 
 * `PORTAL_HTTP_PORT`
 Port used for HTTP portal redirection.
-**Default:** `80`
+**Default: 80** 
 
 * `PORTAL_HTTPS_PORT`
 Port used for HTTPS portal redirection.
-**Default:** `8843`
+**Default: 8843** 
 
 * `UNIFI_STDOUT`
 Controller outputs logs to stdout in addition to server.log
-**Default:** `unset`
+**Default: unset** 
 
 * `TZ`
 TimeZone. (i.e America/Chicago)
@@ -280,7 +246,7 @@ Example:
    --env JVM_MAX_THREAD_STACK_SIZE=1280k
    ```
 
-   as a fix for https://community.ubnt.com/t5/UniFi-Routing-Switching/IMPORTANT-Debian-Ubuntu-users-MUST-READ-Updated-06-21/m-p/1968251#M48264
+   as a fix for [https://community.ubnt.com/t5/UniFi-Routing-Switching/IMPORTANT-Debian-Ubuntu-users-MUST-READ-Updated-06-21/m-p/1968251#M48264](https://community.ubnt.com/t5/UniFi-Routing-Switching/IMPORTANT-Debian-Ubuntu-users-MUST-READ-Updated-06-21/m-p/1968251#M48264)
 
 * `LOTSOFDEVICES`
 Enable this with `true` if you run a system with a lot of devices
@@ -295,37 +261,24 @@ This makes a few adjustments to try and improve performance:
 
    See [the Unifi support site](https://help.ui.com/hc/en-us/articles/115005159588-UniFi-How-to-Tune-the-Network-Application-for-High-Number-of-UniFi-Devices)
 for an explanation of some of those options.
-**Default:** `unset`
+**Default: unset** 
 
 * `JVM_EXTRA_OPTS`
 Used to start the JVM with additional arguments.
-**Default:** `unset`
+**Default: unset** 
 
 * `JVM_INIT_HEAP_SIZE`
 Set the starting size of the javascript engine for example: `1024M`
-**Default:** `unset`
+**Default: unset** 
 
 * `JVM_MAX_HEAP_SIZE`
 Java Virtual Machine (JVM) allocates available memory. 
 For larger installations a larger value is recommended. For memory constrained system this value can be lowered. 
-**Default:** `1024M`
-
-### External MongoDB environment variables
-
-These variables are used to implement support for an [external MongoDB server](https://community.ubnt.com/t5/UniFi-Wireless/External-MongoDB-Server/td-p/1305297) and must all be set in order for this feature to work. Once all are set then the configuration file value for `db.mongo.local` will automatically be set to `false`.
-
-* `DB_URI`
-Maps to `db.mongo.uri`.
-
-* `STATDB_URI`
-Maps to `statdb.mongo.uri`.
-
-* `DB_NAME`
-Maps to `unifi.db.name`.
+**Default: 1024M** 
 
 ## Exposed Ports
 
-This container exposes the following ports.
+The Unifi-in-Docker container exposes the following ports.
 A minimal Unifi Controller installation requires you
 expose the first three with the `-p ...` option.
 
@@ -354,109 +307,6 @@ If you must do this, also pass the
 `--sysctl net.ipv4.ip_unprivileged_port_start=0`
 option on the `docker run...` to bind to whatever port you wish.
 
-~~## Unifi-in-Docker on Windows~~
-
-~~Unifi uses the Mongo database to store its data.
-Mongo uses the fsync() system call on its data files.
-Because of how Docker for Windows works, you can't bind mount `/unifi/db/data` on a Docker for Windows container.~~
-
-~~The article [MongoDB on Windows in Minutes with Docker](https://blog.jeremylikness.com/blog/2018-12-27_mongodb-on-windows-in-minutes-with-docker/) also provides guidance for setting up a Docker Volume to work with Mongo database.~~
-
-~~As a simpler alternative,
-use the `docker-compose` command as described
-in the next section since it uses a pre-built
-Mongo container that addresses the problem.~~
-
-## Running with separate Mongo container
-
-_[ Should we remove this section?
-The simple all-in-one container above works just fine
-for people who "just want it to work" ]_
-
-The `docker-compose.yml` file in this repository provides a
-single command that orchestrates all the actions required
-to bring up Mongo and Unifi Controller in separate containers,
-using named volumes for important directories.
-(No need to worry about the fsync() problem described above.)
-
-Simply clone this repo or copy the `docker-compose.yml` file
-to your host computer's local disk and run:
-
-```bash
-cd <directory with docker-compose.yml>
-docker-compose up -d 
-```
-
-**Setting Options:**
-
-* The `docker-compose.yml` file contains the options
-passed to Unifi Controller when it starts.
-Edit the `docker-compose.yml` file setting its values according to the 
-[Options on the command line.](#options-on-the-command-line)
-* _Optional:_ Add additional `-e <any-environment-variables-you-want>` to the `docker-compose up` line
-
-To change options to Unifi Controller::
-
-```bash
-cd <directory with docker-compose.yml>
-docker-compose down # this stops Unifi Controller and MongoDB
-# ... edit the options in the docker-compose.yml file ...
-docker-compose up ... # to resume operation
-```
-
-## Beta Users
-
-The `beta` image has been updated to support package installation at run time.
-With this change you can now install the beta releases on more systems,
-such as Synology.
-This should open up access to the beta program for more users of this docker image.
-
-If you would like to submit a new feature for the images,
-the beta branch is probably a good one to apply it against as well.
-I will be cleaing up the Dockerfile under beta and gradually pushing out
-the improvements to the other branches.
-So any major changes should apply cleanly against the `beta` branch.
-
-### Installing Beta Builds On The Command Line
-
-Using the Beta build is pretty easy:
-just substitute the correct URL from the Unifi site
-for the `PKGURL` parameter,
-and use `jacobalberty/unifi:beta` for the image
-like this:
-
-```bash
-docker run -d --init \
-   --restart=unless-stopped \
-   -p 8080:8080 -p 8443:8443 -p 3478:3478/udp \
-   -e TZ='Africa/Johannesburg' \
-   -v ~/unifi:/unifi \
-   --user unifi \
-   --name unifi \
-   -e PKGURL=https://dl.ubnt.com/unifi/5.6.30/unifi_sysvinit_all.deb \
-   jacobalberty/unifi:beta
-```
-
-### Running the Beta Using `docker-compose.yml` 
-
-In the containers service definition of the `docker-compose.yml` file, replace `image: jacobalberty/unifi` with the following:
-
-```shell
-        image: jacobalberty/unifi:beta
-         environment:
-          PKGURL: https://dl.ubnt.com/unifi/5.6.40/unifi_sysvinit_all.deb
-```
-
-Replace the PKGURL: link with a link to the package you want.
-
-~~_[Earlier versions talked about "Version 2". Is it still relevant to mention it?]_~~
-
-## Init scripts
-
-~~_[Is this section still true? Relevant?]_~~
-
-You may now place init scripts to be launched during the unifi startup in /usr/local/unifi/init.d to perform any actions unique to your unifi setup. An example bash script to set up certificates is in `/usr/unifi/init.d/import_cert`.
-
 ## Certificate Support
 
 To use custom SSL certs, you must map a volume with the certs to `/unifi/cert`
@@ -473,24 +323,11 @@ If your certificate or private key have different names, you can set the environ
 
 For letsencrypt certs, we'll autodetect that and add the needed Identrust X3 CA Cert automatically. In case your letsencrypt cert is already the chained certificate, you can set the `CERT_IS_CHAIN` environment variable to `true`, e.g. `CERT_IS_CHAIN=true`. This option also works together with a custom `CERTNAME`.
 
-~~### multiarch~~
+## Additional Information
 
-~~_[Is this section still true? Relevant? Do the currently-listed Tags make this section obsolete?]_~~
-
-~~All available containers now support multiarch with `amd64`, `armhf`, and `arm64` builds included.
-`armhf` for now uses mongodb 3.4, I do not see much of a path forward for `armhf` due
-to the lack of mongodb support for 32 bit arm, but I will
-support it as long as feasibly possible, for now that date seems to be expiration of support for ubuntu 18.04.~~
-
-~~## Multi-process container~~
-
-~~_[Is this section still true? Relevant? Does the `docker-compose`section supercede this?]_~~
-
-~~While micro-service patterns try to avoid running multiple processes in a container, the unifi5 container tries to follow the same process execution model intended by the original debian package and its init script, while trying to avoid needing to run a full init system.~~
-
-~~`dumb-init` has now been removed. Instead it is now suggested you include --init in your docker run command line. If you are using docker-compose you can accomplish the same by making sure you use version 2.2 of the yml format and add `init: true` to your service definition.~~
-
-~~`unifi.sh` executes and waits on the jsvc process which orchestrates running the controller as a service. The wrapper script also traps SIGTERM to issue the appropriate stop command to the unifi java `com.ubnt.ace.Launcher` process in the hopes that it helps keep the shutdown graceful.~~
+This document describes everything you need to get Unifi-in-Docker running.
+The [Side Projects and Background Info](./Side-Projects.md) page
+provides more about what we've learned while developing Unifi-in-Docker.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -113,25 +113,21 @@ See [Mongo and Docker for Windows](#mongo-and-docker-for-windows) for more detai
 
 ## Supported Tags
 
-_[**Note:** Docker's rule is to retrieve `:latest` if no tag is specified.
-Newcomers should not be using an RC version,
-so I suggest that we tag the most recent stable version with `:latest`.
-Someone who wants the release candidate can add the `:development` tag -richb]_
-
-You may specify the version of Unifi Controller in the `docker run ...` command.
+You can specify the version of Unifi Controller in the `docker run ...` command.
 For example, the container named `jacobalberty/unifi` provides the most recent stable release.
 See the table below for the current version.
 
-The `development` tag (for example, `jacobalberty/unifi:development`)
-uses the most recent version from the UniFi APT repository,
-whether stable, or an experimental release candidate.
+The `rc` tag (for example, `jacobalberty/unifi:rc`)
+uses the most recent release candidate from the UniFi APT repository.
 
 You may also specify a version number (e.g., `jacobalberty/unifi:6.2.26`) to get a specific version number, as shown in the table below.
 
+_????? Which older versions are actually available? We should list only those... -richb_
+
 | Tag | Description | Changelog |
 |-----|-------------|-----------|
-| [`latest`, `v7`, `v7.1`, `7.1.66`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.1.66 as of 2022-05-18 |[Change Log 7.1.66](https://community.ui.com/releases/UniFi-Network-Application-7-1-66/cf1208d2-3898-418c-b841-699e7b773fd4)|
-| [`development`](https://github.com/jacobalberty/unifi-docker/blob/7.1.67/Dockerfile) | Release Candidate: 7.1.67-rc as of yyyy-mm-dd | [Change Log 7.1.67-rc](https://community.ui.com/releases/UniFi-Network-Application-7-1-67/f85ec723-ae52-405b-8905-077afcc97bb5) |
+| [`latest`, `7.1.66`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.1.66 as of 2022-05-18 |[Change Log 7.1.66](https://community.ui.com/releases/UniFi-Network-Application-7-1-66/cf1208d2-3898-418c-b841-699e7b773fd4)|
+| [`rc`](https://github.com/jacobalberty/unifi-docker/blob/7.1.67/Dockerfile) | Release Candidate: 7.1.67-rc as of yyyy-mm-dd | [Change Log 7.1.67-rc](https://community.ui.com/releases/UniFi-Network-Application-7-1-67/f85ec723-ae52-405b-8905-077afcc97bb5) |
 | `6.2.26` | Earlier 6.2.26 version | link to changelog |
 | `5.8.x` | Earlier 5.8.x version (if available) | link to changelog |
 | `5.6.x` _(available?)_ | Earlier 5.86.x version (if available) | link to changelog |

--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ No more hassling with Controller, Java, or OS updates:
 a Docker container simplifies the installation procedure
 and eliminates problems with dependencies and versions.
 
-The current version is Unifi Controller 7.1.66.
 This container has been tested on Ubuntu, Debian, macOS,
-and even Raspberry Pi hardware. 
+and even Raspberry Pi hardware.
+For information about running on Windows, see [Unifi-in-Docker on Windows](#unifi-in-docker-on-windows) below.
+
+## Current Information
+
+The current version is Unifi Controller 7.1.66.
+There are currently no hot-fix or CVE warnings affecting Unifi Controller.
 
 ## Setting up, Running, Stopping, Upgrading Unifi-in-Docker
 
@@ -21,21 +26,24 @@ and start the Docker container running.
 ### Setting up directories
 
 One-time setup: create the "unifi" directory on the Docker host.
-(By default, this README assumes you will use the home directory.
-If you create the directory elsewhere, read the **Options**
-section below to adjust.)
 Within the "unifi" directory, create two sub-directories: "data" and "log".
 
 ```bash
-cd      # by default, use the home directory
+cd # by default, use the home directory
 mkdir -p unifi/data
 mkdir -p unifi/log
 ```
 
+_Note:_ By default, this README assumes you will use the home directory
+on Linux, Unix, macOS.
+If you create the directory elsewhere, read the
+[Options section](#options-on-the-command-line)
+below to adjust.)
+
 ### Running Unifi-in-Docker
 
 Each time you want to start Unifi, use this command.
-Each of the options is described below.
+Each of the options is [described below.](#options-on-the-command-line)
 
 ```bash
 docker run -d --init \
@@ -65,6 +73,8 @@ Unifi devices can "find" the Unifi Controller.
 
 To change options, stop the Docker container then re-run the `docker run...` command
 above with the new options.
+_Note:_ The `docker rm unifi` command simply removes the "name" from the previous Docker image.
+No time-consuming rebuild is required.
 
 ```bash
 docker stop unifi
@@ -73,7 +83,7 @@ docker rm unifi
 ### Upgrading Unifi Controller
 
 All the configuration and other files created by Unifi Controller
-are stored on the Docker host's local disk.
+are stored on the Docker host's local disk (`~/unifi` by default.)
 No information is retained within the container.
 An upgrade to a new version of Unifi Controller simply retrieves a new Docker container,
 which then re-uses the configuration from the local disk.
@@ -81,9 +91,9 @@ The upgrade process is:
 
 1. **MAKE A BACKUP** on another computer, not the Docker host _(Always, every time...)_
 2. Stop the current container (see above)
-3. Enter `docker run...` with the new container name (see above)
+3. Enter `docker run...` with the newer container tag (see [Supported Tags](#supported-tags) below.)
 
-## Options for Unifi-in-Docker
+## Options on the Command Line
 
 The options for the `docker run...` command are:
 
@@ -92,7 +102,7 @@ The options for the `docker run...` command are:
 - `--restart=unless-stopped` - If the container should stop for some reason,
 restart it unless you issue a `docker stop ...`
 - `-p ...` - Set the ports to pass through to the container.
-The list above - `-p 8080:8080 -p 8443:8443 -p 3478:3478/udp`
+`-p 8080:8080 -p 8443:8443 -p 3478:3478/udp`
 is the minimal set for a working Unifi Controller. 
 - `-e TZ=...` Set an environment variable named `TZ` with the desired time zone.
 Find your time zone in this 
@@ -108,71 +118,34 @@ See the [Volumes](#volumes) discussion for other volumes used by Unifi Controlle
 - `jacobalberty/unifi` - the name of the container to use.
 The `jacobalberty...` image is retrieved from [Dockerhub.](https://hub.docker.com/r/jacobalberty/unifi)
 See the discussion about [Supported Tags](#supported-docker-hub-tags-and-respective-dockerfile-links) below.
-- **Windows Users:** There is a problem with Mongo database and a bind-mount volume.
-See [Mongo and Docker for Windows](#mongo-and-docker-for-windows) for more details.
+- **Windows Users:** For information about running on Windows, see [Unifi-in-Docker on Windows](#unifi-in-docker-on-windows) below.
 
 ## Supported Tags
 
-You can specify the version of Unifi Controller in the `docker run ...` command.
-For example, the container named `jacobalberty/unifi` provides the most recent stable release.
+You can choose the version of Unifi Controller in the `docker run ...` command.
+In Docker terminology, these versions are specified by "tags".
+
+For example, in this project the container named `jacobalberty/unifi`
+(with no "tag")
+provides the most recent stable release.
 See the table below for the current version.
 
 The `rc` tag (for example, `jacobalberty/unifi:rc`)
 uses the most recent release candidate from the UniFi APT repository.
 
-You may also specify a version number (e.g., `jacobalberty/unifi:6.2.26`) to get a specific version number, as shown in the table below.
+You may also specify a version number (e.g., `jacobalberty/unifi:stable6`)
+to get a specific version number, as shown in the table below.
 
-_????? Which older versions are actually available? We should list only those... -richb_
+_Note:_ In Docker, specifying an image with no tag 
+(e.g., `jacobalberty/unifi`) gets the "latest" tag.
+For Unifi-in-Docker, this uses the most recent stable version.
 
 | Tag | Description | Changelog |
 |-----|-------------|-----------|
 | [`latest`, `7.1.66`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.1.66 as of 2022-05-18 |[Change Log 7.1.66](https://community.ui.com/releases/UniFi-Network-Application-7-1-66/cf1208d2-3898-418c-b841-699e7b773fd4)|
-| [`rc`](https://github.com/jacobalberty/unifi-docker/blob/7.1.67/Dockerfile) | Release Candidate: 7.1.67-rc as of yyyy-mm-dd | [Change Log 7.1.67-rc](https://community.ui.com/releases/UniFi-Network-Application-7-1-67/f85ec723-ae52-405b-8905-077afcc97bb5) |
-| `6.2.26` | Earlier 6.2.26 version | link to changelog |
-| `5.8.x` | Earlier 5.8.x version (if available) | link to changelog |
-| `5.6.x` _(available?)_ | Earlier 5.86.x version (if available) | link to changelog |
-
-### multiarch
-
-All available containers now support multiarch with `amd64`, `armhf`, and `arm64` builds included.
-`armhf` for now uses mongodb 3.4, I do not see much of a path forward for `armhf` due
-to the lack of mongodb support for 32 bit arm, but I will
-support it as long as feasibly possible, for now that date seems to be expiration of support for ubuntu 18.04.
-
-## Run as non-root User
-
-It is suggested you start running the Unifi Controller as a non-root user.
-The default container runs it as root but if you set the docker run flag `--user` to `unifi`,
-then the image will run as a special unfi user with the uid/gid 999/999.
-You should ideally set your data and logs to owned by the proper gid.
-
-Note: If you run as `unifi`, you will not be able to bind to lower ports by default.
-This should not be needed if you are using the default ports.
-If you need this, also pass the `docker run ...` flag `--sysctl` with `net.ipv4.ip_unprivileged_port_start=0`
-to bind to whatever port you wish.
-
-## Mongo and Docker for windows
-Unifi uses the Mongo database to store its data.
-Mongo uses the fsync() system call on its data files.
-Because of how Docker for Windows works, you can't bind mount `/unifi/db/data` on a Docker for Windows container.
-
-_[**IS THIS NEXT SENTENCE TRUE?** -richb]_ You can keep data locally but should use `-v unifi:/unifi` (no leading `~/`) and be sure to create those directories in the right place.
-
-The article [MongoDB on Windows in Minutes with Docker](https://blog.jeremylikness.com/blog/2018-12-27_mongodb-on-windows-in-minutes-with-docker/) also provides guidance for setting up a Docker Volume to work with Mongo database.
-
-## Running with separate mongo container
-
-The `docker-compose.yml` file will bring up mongo and the controller,
-using named volumes for important directories.
-
-Simply clone this repo or copy the `docker-compose.yml` file
-to you host computer's local disk and run:
-
-```bash
-docker-compose up -d
-```
-
-_[Should we simply recommend Windows users use the `docker-compose`? How would they set up options? Would it matter?_
+| [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile) | Release Candidate: 7.1.67-rc as of yyyy-mm-dd | [Change Log 7.1.67-rc](https://community.ui.com/releases/UniFi-Network-Application-7-1-67/f85ec723-ae52-405b-8905-077afcc97bb5) |
+| [`stable6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
+| [`stable5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |
 
 ## Adopting Access Points/Switches/Security Gateway
 
@@ -234,41 +207,6 @@ If you launch the container using host networking \(With the `--net=host` parame
 It is possible to configure the `macvlan` driver to bridge your container to the host's networking adapter.
 Specific instructions for this container are not yet available but you can read a write-up for docker at
 [collabnix.com/docker-17-06-swarm-mode-now-with-macvlan-support](http://collabnix.com/docker-17-06-swarm-mode-now-with-macvlan-support/).
-
-## Beta Users
-
-The `beta` image has been updated to support package installation at run time.
-With this change you can now install the beta releases on more systems,
-such as Synology.
-This should open up access to the beta program for more users of this docker image.
-
-
-If you would like to submit a new feature for the images,
-the beta branch is probably a good one to apply it against as well.
-I will be cleaing up the Dockerfile under beta and gradually pushing out
-the improvements to the other branches.
-So any major changes should apply cleanly against the `beta` branch.
-
-### Installing Beta Builds On The Command Line
-
-Using the Beta build is pretty easy, just use the `jacobalberty/unifi:beta` image
-and add `-e PKGURL=https://dl.ubnt.com/unifi/5.6.30/unifi_sysvinit_all.deb` to your usual command line.
-
-Simply replace the url to the debian package with the version you prefer.
-
-### Building Beta Using `docker-compose.yml` Version 2
-
-This is just as easy when using version 2 of the docker-compose.yml file format.
-
-Under your containers service definition instead of using `image: jacobalberty/unifi` use the following:
-
-```shell
-        image: jacobalberty/unifi:beta
-         environment:
-          PKGURL: https://dl.ubnt.com/unifi/5.6.40/unifi_sysvinit_all.deb
-```
-
-Once again, simply change PKGURL to point to the package you would like to use.
 
 ## Volumes
 
@@ -391,14 +329,96 @@ This container exposes the following ports. A minimal Unifi Controller requires 
 
 See [UniFi - Ports Used](https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used) for more information.
 
-## Multi-process container
-_[Is this section still true? Relevant?]_
+## Run as non-root User
 
-While micro-service patterns try to avoid running multiple processes in a container, the unifi5 container tries to follow the same process execution model intended by the original debian package and its init script, while trying to avoid needing to run a full init system.
+It is suggested you start running the Unifi Controller as a non-root user.
+The default container runs it as root but if you set the docker run flag `--user` to `unifi`,
+then the image will run as a special unfi user with the uid/gid 999/999.
+You should ideally set your data and logs to owned by the proper gid.
 
-`dumb-init` has now been removed. Instead it is now suggested you include --init in your docker run command line. If you are using docker-compose you can accomplish the same by making sure you use version 2.2 of the yml format and add `init: true` to your service definition.
+Note: If you run as `unifi`, you will not be able to bind to lower ports by default.
+This should not be needed if you are using the default ports.
+If you need this, also pass the `docker run ...` flag `--sysctl` with `net.ipv4.ip_unprivileged_port_start=0`
+to bind to whatever port you wish.
 
-`unifi.sh` executes and waits on the jsvc process which orchestrates running the controller as a service. The wrapper script also traps SIGTERM to issue the appropriate stop command to the unifi java `com.ubnt.ace.Launcher` process in the hopes that it helps keep the shutdown graceful.
+## Unifi-in-Docker on Windows
+Unifi uses the Mongo database to store its data.
+Mongo uses the fsync() system call on its data files.
+Because of how Docker for Windows works, you can't bind mount `/unifi/db/data` on a Docker for Windows container.
+
+The article [MongoDB on Windows in Minutes with Docker](https://blog.jeremylikness.com/blog/2018-12-27_mongodb-on-windows-in-minutes-with-docker/) also provides guidance for setting up a Docker Volume to work with Mongo database.
+
+Alternatively, use the `docker-compose` command as described
+in the next section since it uses a pre-built
+Mongo container that addresses the problem.
+
+### Running with separate Mongo container
+
+The `docker-compose.yml` file in this repository
+provides single command that orchestrates all the actions required
+to bring up Mongo and Unifi Controller in separate containers,
+using named volumes for important directories.
+
+Simply clone this repo or copy the `docker-compose.yml` file
+to your host computer's local disk and run:
+
+```bash
+cd <directory with docker-compose.yml>
+docker-compose up -d 
+```
+
+**Setting Options:**
+
+* The `docker-compose.yml` file contains the options
+passed to Unifi Controller when it starts.
+Edit that file to modify the options.
+* _Optional:_ Add additional `-e <any-environment-variables-you-want>` to the `docker-compose up` line
+
+To change options to Unifi Controller::
+
+```bash
+cd <directory with docker-compose.yml>
+docker-compose down # this stops Unifi Controller and MongoDB
+... edit the options in the docker-compose.yml file ...
+docker-compose up ... # to resume operation
+```
+
+The options in the `docker-compose.yml` file are described in the 
+[Options on the command line](#options-on-the-command-line) section.
+
+## Beta Users
+
+The `beta` image has been updated to support package installation at run time.
+With this change you can now install the beta releases on more systems,
+such as Synology.
+This should open up access to the beta program for more users of this docker image.
+
+If you would like to submit a new feature for the images,
+the beta branch is probably a good one to apply it against as well.
+I will be cleaing up the Dockerfile under beta and gradually pushing out
+the improvements to the other branches.
+So any major changes should apply cleanly against the `beta` branch.
+
+### Installing Beta Builds On The Command Line
+
+Using the Beta build is pretty easy, just use the `jacobalberty/unifi:beta` image
+and pass in the environment variable `-e PKGURL=https://dl.ubnt.com/unifi/5.6.30/unifi_sysvinit_all.deb` to your usual command line.
+
+Simply replace the url to the debian package with the version you prefer.
+
+### Running the Beta Using `docker-compose.yml` 
+
+In the containers service definition of the `docker-compose.yml` file, replace `image: jacobalberty/unifi` with the following:
+
+```shell
+        image: jacobalberty/unifi:beta
+         environment:
+          PKGURL: https://dl.ubnt.com/unifi/5.6.40/unifi_sysvinit_all.deb
+```
+
+Replace the PKGURL: link with a link to the package you want.
+
+_[Earlier versions talked about "Version 2". Is it still relevant to mention it?]_
 
 ## Init scripts
 
@@ -421,6 +441,24 @@ chain.pem # full cert chain
 If your certificate or private key have different names, you can set the environment variables `CERTNAME` and `CERT_PRIVATE_NAME` to the name of your certificate/private key, e.g. `CERTNAME=my-cert.pem` and `CERT_PRIVATE_NAME=my-privkey.pem`.
 
 For letsencrypt certs, we'll autodetect that and add the needed Identrust X3 CA Cert automatically. In case your letsencrypt cert is already the chained certificate, you can set the `CERT_IS_CHAIN` environment variable to `true`, e.g. `CERT_IS_CHAIN=true`. This option also works together with a custom `CERTNAME`.
+
+### multiarch
+
+_[Is this section still true? Relevant? Do the currently-listed Tags make this section obsolete?]_
+
+All available containers now support multiarch with `amd64`, `armhf`, and `arm64` builds included.
+`armhf` for now uses mongodb 3.4, I do not see much of a path forward for `armhf` due
+to the lack of mongodb support for 32 bit arm, but I will
+support it as long as feasibly possible, for now that date seems to be expiration of support for ubuntu 18.04.
+
+## Multi-process container
+_[Is this section still true? Relevant? Does the `docker-compose`section supercede this?]_
+
+While micro-service patterns try to avoid running multiple processes in a container, the unifi5 container tries to follow the same process execution model intended by the original debian package and its init script, while trying to avoid needing to run a full init system.
+
+`dumb-init` has now been removed. Instead it is now suggested you include --init in your docker run command line. If you are using docker-compose you can accomplish the same by making sure you use version 2.2 of the yml format and add `init: true` to your service definition.
+
+`unifi.sh` executes and waits on the jsvc process which orchestrates running the controller as a service. The wrapper script also traps SIGTERM to issue the appropriate stop command to the unifi java `com.ubnt.ace.Launcher` process in the hopes that it helps keep the shutdown graceful.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker run -d --init \
    -e TZ='Africa/Johannesburg' \
    -v ~/unifi:/unifi \
    --user unifi \
+   --name unifi \
    jacobalberty/unifi
 ```
 
@@ -64,12 +65,10 @@ Unifi devices can "find" the Unifi Controller.
 
 To change options, stop the Docker container then re-run the `docker run...` command
 above with the new options.
-To stop the running container, you need to get its name -
-a two-word phrase, separated by "_", shown at the end of the `docker ps` command.
 
 ```bash
-docker ps # to find the container name - it'll be two_words
-docker stop two_words
+docker stop unifi
+docker rm unifi
 ```
 ### Upgrading Unifi Controller
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ with the address of the Docker host computer.
 (By default, the Docker container usually gets the address 172.17.x.x.)
 To do this:
 
-* Find **Settings -> System -> Override Inform Host:** in the Unifi Controller web GUI.
+* Find **Settings -> System -> Other Configuration -> Override Inform Host:** in the Unifi Controller web GUI.
 * Check the "Enable" box, and enter the IP address of the Docker host machine. 
 * Save settings in Unifi Controller
 * Restart UniFi-in-Docker container with `docker stop ...` and `docker run ...` commands.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 This repo contains a Dockerized version of [Ubiqiti Network's](https://www.ubnt.com/) Unifi Controller.
 
-No more hassling with Controller, Java, or OS updates:
-a Docker container simplifies the installation procedure
-and eliminates problems with dependencies and versions.
+**Why bother?** Using Docker, you can stop worrying about version
+hassles with Unifi Controller, Java, _and_ your OS.
+A Docker container wraps everything into one well-tested bundle.
+
+To install, a couple lines on the command-line starts the container.
+To upgrade, just stop the old container, and start up the new.
+It's really that simple.
 
 This container has been tested on Ubuntu, Debian, macOS,
 and even Raspberry Pi hardware.
@@ -12,14 +16,15 @@ For information about running on Windows, see [Unifi-in-Docker on Windows](#unif
 
 ## Current Information
 
-The current version is Unifi Controller 7.1.66.
+The current "latest" version is Unifi Controller 7.1.66.
 There are currently no hot-fix or CVE warnings affecting Unifi Controller.
 
-## Setting up, Running, Stopping, Upgrading Unifi-in-Docker
+## Setting up, Running, Stopping, Upgrading
 
-First, install Docker on the machine that will run the Docker
-and Unifi Controller software (the "Docker host")
-using any of the guides on the internet.
+First, install Docker on the the "Docker host" -
+the machine that will run the Docker
+and Unifi Controller software.
+Use any of the guides on the internet to install on your Docker host.
 Then use the following steps to set up the directories
 and start the Docker container running.
 
@@ -62,10 +67,10 @@ to complete configuration from the web (initial install) or resume using Unifi C
 
 **Important:** Two points to be aware of when you're setting up your Unifi Controller:
 
-* When you initially connect to the link above, you will
+* When your browser initially connects to the link above, you will
 see a warning about an untrusted certificate.
-If you are _sure_ that you have used the address of the host
-running Unifi-in-Docker, agree to the connection.
+If you are _certain_ that you have typed the address of the
+Docker host correctly, agree to the connection.
 * See the note below about **Override "Inform Host" IP** so your
 Unifi devices can "find" the Unifi Controller.
  
@@ -318,28 +323,34 @@ Maps to `unifi.db.name`.
 
 ## Exposed Ports
 
-This container exposes the following ports. A minimal Unifi Controller requires the first three.
+This container exposes the following ports.
+A minimal Unifi Controller installation requires you
+expose the first three with the `-p ...` option.
 
-* 8080/tcp - Device command/control
-* 8443/tcp - Web interface + API
-* 3478/udp - STUN service
-* 8843/tcp - HTTPS portal
-* 8880/tcp - HTTP portal
-* 6789/tcp - Speed Test (unifi5 only)
+* 8080/tcp - Device command/control 
+* 8443/tcp - Web interface + API 
+* 3478/udp - STUN service 
+* 8843/tcp - HTTPS portal _(optional)_
+* 8880/tcp - HTTP portal _(optional)_
+* 6789/tcp - Speed Test (unifi5 only) _(optional)_
 
 See [UniFi - Ports Used](https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used) for more information.
 
 ## Run as non-root User
 
-It is suggested you start running the Unifi Controller as a non-root user.
-The default container runs it as root but if you set the docker run flag `--user` to `unifi`,
-then the image will run as a special unfi user with the uid/gid 999/999.
-You should ideally set your data and logs to owned by the proper gid.
+The default container runs Unifi Controller as root.
+The recommended `docker run...` command above starts
+Unifi Controller so the image runs as `unifi` (non-root)
+user with the uid/gid 999/999.
+You can also set your data and logs directories to be
+owned by the proper gid.
 
-Note: If you run as `unifi`, you will not be able to bind to lower ports by default.
-This should not be needed if you are using the default ports.
-If you need this, also pass the `docker run ...` flag `--sysctl` with `net.ipv4.ip_unprivileged_port_start=0`
-to bind to whatever port you wish.
+_Note:_ When you run as a non-root user,
+you will not be able to bind to lower ports by default.
+(This would not necessary if you are using the default ports.)
+If you must do this, also pass the 
+`--sysctl net.ipv4.ip_unprivileged_port_start=0`
+option on the `docker run...` to bind to whatever port you wish.
 
 ## Unifi-in-Docker on Windows
 Unifi uses the Mongo database to store its data.
@@ -348,16 +359,18 @@ Because of how Docker for Windows works, you can't bind mount `/unifi/db/data` o
 
 The article [MongoDB on Windows in Minutes with Docker](https://blog.jeremylikness.com/blog/2018-12-27_mongodb-on-windows-in-minutes-with-docker/) also provides guidance for setting up a Docker Volume to work with Mongo database.
 
-Alternatively, use the `docker-compose` command as described
+As a simpler alternative,
+use the `docker-compose` command as described
 in the next section since it uses a pre-built
 Mongo container that addresses the problem.
 
 ### Running with separate Mongo container
 
-The `docker-compose.yml` file in this repository
-provides single command that orchestrates all the actions required
+The `docker-compose.yml` file in this repository provides a
+single command that orchestrates all the actions required
 to bring up Mongo and Unifi Controller in separate containers,
 using named volumes for important directories.
+(No need to worry about the fsync() problem described above.)
 
 Simply clone this repo or copy the `docker-compose.yml` file
 to your host computer's local disk and run:
@@ -371,7 +384,8 @@ docker-compose up -d
 
 * The `docker-compose.yml` file contains the options
 passed to Unifi Controller when it starts.
-Edit that file to modify the options.
+Edit the `docker-compose.yml` file setting its values according to the 
+[Options on the command line.](#options-on-the-command-line)
 * _Optional:_ Add additional `-e <any-environment-variables-you-want>` to the `docker-compose up` line
 
 To change options to Unifi Controller::
@@ -379,12 +393,9 @@ To change options to Unifi Controller::
 ```bash
 cd <directory with docker-compose.yml>
 docker-compose down # this stops Unifi Controller and MongoDB
-... edit the options in the docker-compose.yml file ...
+# ... edit the options in the docker-compose.yml file ...
 docker-compose up ... # to resume operation
 ```
-
-The options in the `docker-compose.yml` file are described in the 
-[Options on the command line](#options-on-the-command-line) section.
 
 ## Beta Users
 
@@ -418,11 +429,11 @@ In the containers service definition of the `docker-compose.yml` file, replace `
 
 Replace the PKGURL: link with a link to the package you want.
 
-_[Earlier versions talked about "Version 2". Is it still relevant to mention it?]_
+~~_[Earlier versions talked about "Version 2". Is it still relevant to mention it?]_~~
 
 ## Init scripts
 
-_[Is this section still true? Relevant?]_
+~~_[Is this section still true? Relevant?]_~~
 
 You may now place init scripts to be launched during the unifi startup in /usr/local/unifi/init.d to perform any actions unique to your unifi setup. An example bash script to set up certificates is in `/usr/unifi/init.d/import_cert`.
 
@@ -442,23 +453,24 @@ If your certificate or private key have different names, you can set the environ
 
 For letsencrypt certs, we'll autodetect that and add the needed Identrust X3 CA Cert automatically. In case your letsencrypt cert is already the chained certificate, you can set the `CERT_IS_CHAIN` environment variable to `true`, e.g. `CERT_IS_CHAIN=true`. This option also works together with a custom `CERTNAME`.
 
-### multiarch
+~~### multiarch~~
 
-_[Is this section still true? Relevant? Do the currently-listed Tags make this section obsolete?]_
+~~_[Is this section still true? Relevant? Do the currently-listed Tags make this section obsolete?]_~~
 
-All available containers now support multiarch with `amd64`, `armhf`, and `arm64` builds included.
+~~All available containers now support multiarch with `amd64`, `armhf`, and `arm64` builds included.
 `armhf` for now uses mongodb 3.4, I do not see much of a path forward for `armhf` due
 to the lack of mongodb support for 32 bit arm, but I will
-support it as long as feasibly possible, for now that date seems to be expiration of support for ubuntu 18.04.
+support it as long as feasibly possible, for now that date seems to be expiration of support for ubuntu 18.04.~~
 
-## Multi-process container
-_[Is this section still true? Relevant? Does the `docker-compose`section supercede this?]_
+~~## Multi-process container~~
 
-While micro-service patterns try to avoid running multiple processes in a container, the unifi5 container tries to follow the same process execution model intended by the original debian package and its init script, while trying to avoid needing to run a full init system.
+~~_[Is this section still true? Relevant? Does the `docker-compose`section supercede this?]_~~
 
-`dumb-init` has now been removed. Instead it is now suggested you include --init in your docker run command line. If you are using docker-compose you can accomplish the same by making sure you use version 2.2 of the yml format and add `init: true` to your service definition.
+~~While micro-service patterns try to avoid running multiple processes in a container, the unifi5 container tries to follow the same process execution model intended by the original debian package and its init script, while trying to avoid needing to run a full init system.~~
 
-`unifi.sh` executes and waits on the jsvc process which orchestrates running the controller as a service. The wrapper script also traps SIGTERM to issue the appropriate stop command to the unifi java `com.ubnt.ace.Launcher` process in the hopes that it helps keep the shutdown graceful.
+~~`dumb-init` has now been removed. Instead it is now suggested you include --init in your docker run command line. If you are using docker-compose you can accomplish the same by making sure you use version 2.2 of the yml format and add `init: true` to your service definition.~~
+
+~~`unifi.sh` executes and waits on the jsvc process which orchestrates running the controller as a service. The wrapper script also traps SIGTERM to issue the appropriate stop command to the unifi java `com.ubnt.ace.Launcher` process in the hopes that it helps keep the shutdown graceful.~~
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -7,49 +7,65 @@ a Docker container simplifies the installation procedure
 and eliminates problems with dependencies and versions.
 
 The current version is Unifi Controller 7.1.66.
-This container has been tested on Ubuntu, Debian, and even Raspberry Pi hardware. 
+This container has been tested on Ubuntu, Debian, macOS,
+and even Raspberry Pi hardware. 
 
 ## Setting up, Running, Stopping, Upgrading Unifi-in-Docker
 
-First, install Docker on your machine (the "Docker host")
+First, install Docker on the machine that will run the Docker
+and Unifi Controller software (the "Docker host")
 using any of the guides on the internet.
-Then set up the directories and start the Docker container running.
+Then use the following steps to set up the directories
+and start the Docker container running.
 
 ### Setting up directories
 
+One-time setup: create the "unifi" directory on the Docker host.
+(By default, this README assumes you will use the home directory.
+If you create the directory elsewhere, read the **Options**
+section below to adjust.)
+Within the "unifi" directory, create two sub-directories: "data" and "log".
+
 ```bash
-cd 	# by default, use the home directory
+cd      # by default, use the home directory
 mkdir -p unifi/data
 mkdir -p unifi/log
 ```
 
 ### Running Unifi-in-Docker
 
-Each time you want to start Unifi, use these commands:
+Each time you want to start Unifi, use this command.
+Each of the options is described below.
 
 ```bash
-cd <directory-to-hold-Unifi-files>
 docker run -d --init \
    --restart=unless-stopped \
    -p 8080:8080 -p 8443:8443 -p 3478:3478/udp \
    -e TZ='Africa/Johannesburg' \
    -v ~/unifi:/unifi \
    --user unifi \
-   jacobalberty/unifi:v7
+   jacobalberty/unifi
 ```
 
 In a minute or two, (after Unifi Controller starts up) you can go to
-[https://your-server-address:8443](https://your-server-address:8443)
+[https://docker-host-address:8443](https://docker-host-address:8443)
 to complete configuration from the web (initial install) or resume using Unifi Controller.
 
-**Important:** See the note below about Overriding the "Inform Host" IP during initial configuration.
+**Important:** Two points to be aware of when you're setting up your Unifi Controller:
 
+* When you initially connect to the link above, you will
+see a warning about an untrusted certificate.
+If you are _sure_ that you have used the address of the host
+running Unifi-in-Docker, agree to the connection.
+* See the note below about **Override "Inform Host" IP** so your
+Unifi devices can "find" the Unifi Controller.
+ 
 ### Stopping Unifi-in-Docker
 
 To change options, stop the Docker container then re-run the `docker run...` command
 above with the new options.
-To do this, you need to get the name for the running container.
-It's a two-word phrase, separated by "_", shown at the end of the `docker ps` command.
+To stop the running container, you need to get its name -
+a two-word phrase, separated by "_", shown at the end of the `docker ps` command.
 
 ```bash
 docker ps # to find the container name - it'll be two_words
@@ -57,9 +73,12 @@ docker stop two_words
 ```
 ### Upgrading Unifi Controller
 
-All the files created/maintained by Unifi Controller actually live on the host's volume.
+All the configuration and other files created by Unifi Controller
+are stored on the Docker host's local disk.
+No information is retained within the container.
 An upgrade to a new version of Unifi Controller simply retrieves a new Docker container,
-reusing the configuration from the local disk. The process is:
+which then re-uses the configuration from the local disk.
+The upgrade process is:
 
 1. **MAKE A BACKUP** on another computer, not the Docker host _(Always, every time...)_
 2. Stop the current container (see above)
@@ -70,108 +89,118 @@ reusing the configuration from the local disk. The process is:
 The options for the `docker run...` command are:
 
 - `-d` - Detached mode: Unifi-in-Docker runs in the background
-- `--init` - Recommended to ensure processes get reaped
+- `--init` - Recommended to ensure processes get reaped when they die
 - `--restart=unless-stopped` - If the container should stop for some reason,
 restart it unless you issue a `docker stop ...`
-- `-p 8443:8443` - Set the ports to pass through to the container.
-The list above is the minimal set for a working Unifi Controller. 
-- `-e TZ=...` Set an environment variable named `TZ` with the desired time zone
-([list of timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))
+- `-p ...` - Set the ports to pass through to the container.
+The list above - `-p 8080:8080 -p 8443:8443 -p 3478:3478/udp`
+is the minimal set for a working Unifi Controller. 
+- `-e TZ=...` Set an environment variable named `TZ` with the desired time zone.
+Find your time zone in this 
+[list of timezones.](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 - `-e ...` See the [Environment Variables](#environment-variables)
 section for more environment variables.
-- `-v ...` - Bind the volume `~/unifi` on the host to the directory `/unifi`inside the container.
+- `-v ...` - Bind the volume `~/unifi` on the Docker host
+to the directory `/unifi`inside the container.
+**These instructions assume you placed the "unifi" directory in your home directory.**
+If you created the directory elsewhere, modify the `~/unifi` part of this option to match.
 See the [Volumes](#volumes) discussion for other volumes used by Unifi Controller.
 - `--user unifi` - Run as a non-root user. See the [Run as non-root User](#run-as-non-root-user) discussion below
-- `jacobalberty/unifi:7` - the name of the container to use.
-The `jacobalberty...` image comes from [Dockerhub.](https://hub.docker.com/r/jacobalberty/unifi)
+- `jacobalberty/unifi` - the name of the container to use.
+The `jacobalberty...` image is retrieved from [Dockerhub.](https://hub.docker.com/r/jacobalberty/unifi)
 See the discussion about [Supported Tags](#supported-docker-hub-tags-and-respective-dockerfile-links) below.
 - **Windows Users:** There is a problem with Mongo database and a bind-mount volume.
-You can keep data locally but should use `-v unifi:/unifi` (no leading `~/`)
-**_IS THIS TRUE?_** See [Mongo and Docker for Windows](#mongo-and-docker-for-windows) for more details.
+See [Mongo and Docker for Windows](#mongo-and-docker-for-windows) for more details.
 
-## Supported Docker Hub Tags and Respective `Dockerfile` Links
+## Supported Tags
 
-### "latest" tag
+_[**Note:** Docker's rule is to retrieve `:latest` if no tag is specified.
+Newcomers should not be using an RC version,
+so I suggest that we tag the most recent stable version with `:latest`.
+Someone who wants the release candidate can add the `:development` tag -richb]_
 
-`latest` now tracks unifi 7.1.x as of 2022-05-18.
+You may specify the version of Unifi Controller in the `docker run ...` command.
+For example, the container named `jacobalberty/unifi` provides the most recent stable release.
+See the table below for the current version.
 
-| Tag | Description |
-|-----|-------------|
-| [`latest`, `v7`, `v7.1`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Tracks UniFi stable version - 7.1.66 as of 2022-05-18 [Change Log 7.1.66](https://community.ui.com/releases/UniFi-Network-Application-7-1-66/cf1208d2-3898-418c-b841-699e7b773fd4)|
+The `development` tag (for example, `jacobalberty/unifi:development`)
+uses the most recent version from the UniFi APT repository,
+whether stable, or an experimental release candidate.
 
-### Latest Release Candidate tags
+You may also specify a version number (e.g., `jacobalberty/unifi:6.2.26`) to get a specific version number, as shown in the table below.
 
-| Version | Latest Tag |
-|---------|------------|
-| 7.1.x   | [`7.1.66`](https://github.com/jacobalberty/unifi-docker/blob/7.1.66/Dockerfile) |
-
-These tags generally track the UniFi APT repository. We do lead the repository a little when it comes to pushing the latest version. The latest version gets pushed when it moves from `release candidate` to `stable` instead of waiting for it to hit the repository.
-
-In adition to these tags you may tag specific versions as well,
-for example `jacobalberty/unifi:v6.2.26` will get you unifi 6.2.26
-no matter what the current version is.
-For release candidates it is advised to use the specific versions as the `rc` tag
-may jump from 5.6.x to 5.8.x then back to 5.6.x as new release candidates come out.
+| Tag | Description | Changelog |
+|-----|-------------|-----------|
+| [`latest`, `v7`, `v7.1`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.1.66 as of 2022-05-18 |[Change Log 7.1.66](https://community.ui.com/releases/UniFi-Network-Application-7-1-66/cf1208d2-3898-418c-b841-699e7b773fd4)|
+| [`development`](https://github.com/jacobalberty/unifi-docker/blob/7.1.67/Dockerfile) | Release Candidate: 7.1.67-rc as of yyyy-mm-dd | [Change Log 7.1.67-rc](https://community.ui.com/releases/UniFi-Network-Application-7-1-67/f85ec723-ae52-405b-8905-077afcc97bb5) |
+| `6.2.26` | Earlier 6.2.26 version | link to changelog |
+| `5.8.x` | Earlier 5.8.x version (if available) | link to changelog |
+| `5.6.x` _(available?)_ | Earlier 5.86.x version (if available) | link to changelog |
 
 ### multiarch
 
-All tags are now multiarch capable with `amd64`, `armhf`, and `arm64` builds included.
+All available containers now support multiarch with `amd64`, `armhf`, and `arm64` builds included.
 `armhf` for now uses mongodb 3.4, I do not see much of a path forward for `armhf` due
 to the lack of mongodb support for 32 bit arm, but I will
 support it as long as feasibly possible, for now that date seems to be expiration of support for ubuntu 18.04.
 
 ## Run as non-root User
 
-It is suggested you start running this as a non root user.
-The default right now is to run as root but if you set the docker run flag `--user` to `unifi`,
+It is suggested you start running the Unifi Controller as a non-root user.
+The default container runs it as root but if you set the docker run flag `--user` to `unifi`,
 then the image will run as a special unfi user with the uid/gid 999/999.
 You should ideally set your data and logs to owned by the proper gid.
-You will not be able to bind to lower ports by default.
-If you also pass the docker run flag `--sysctl` with `net.ipv4.ip_unprivileged_port_start=0`
-then you will be able to freely bind to whatever port you wish.
+
+Note: If you run as `unifi`, you will not be able to bind to lower ports by default.
 This should not be needed if you are using the default ports.
+If you need this, also pass the `docker run ...` flag `--sysctl` with `net.ipv4.ip_unprivileged_port_start=0`
+to bind to whatever port you wish.
 
 ## Mongo and Docker for windows
- Unifi uses mongo store its data.
- Mongo uses the fsync() system call on its data files.
- Because of how Docker for Windows works, you can't bind mount `/unifi/db/data`
- on a Docker for Windows container.
- Therefore `-v ~/unifi:/unifi` won't work.
-See the [discussion on the issue](https://github.com/docker/for-win/issues/138).
+Unifi uses the Mongo database to store its data.
+Mongo uses the fsync() system call on its data files.
+Because of how Docker for Windows works, you can't bind mount `/unifi/db/data` on a Docker for Windows container.
 
-_Also:_ Does this provide any guidance for Window? https://blog.jeremylikness.com/blog/2018-12-27_mongodb-on-windows-in-minutes-with-docker/
+_[**IS THIS NEXT SENTENCE TRUE?** -richb]_ You can keep data locally but should use `-v unifi:/unifi` (no leading `~/`) and be sure to create those directories in the right place.
+
+The article [MongoDB on Windows in Minutes with Docker](https://blog.jeremylikness.com/blog/2018-12-27_mongodb-on-windows-in-minutes-with-docker/) also provides guidance for setting up a Docker Volume to work with Mongo database.
 
 ## Running with separate mongo container
 
-A compose file has been included that will bring up mongo and the controller,
+The `docker-compose.yml` file will bring up mongo and the controller,
 using named volumes for important directories.
 
-Simply clone this repo or copy the `docker-compose.yml` file and run
+Simply clone this repo or copy the `docker-compose.yml` file
+to you host computer's local disk and run:
+
 ```bash
 docker-compose up -d
 ```
 
-## Adopting Access Points/Switches/Security Gateway
+_[Should we simply recommend Windows users use the `docker-compose`? How would they set up options? Would it matter?_
 
-For your Unifi devices to "find" the Unifi Controller running in Docker, you _MUST_ override the Inform Host IP (described below).
-You may need some of the other techniques below to adopt all the APs.
+## Adopting Access Points/Switches/Security Gateway
 
 #### Override "Inform Host" IP
 
-Configure Unifi Controller to use the address of the Docker host, instead of the internal Docker address (usually 172.17.x.x).
-The way to do this depends on the version of your Unifi Controller:
-* **Current (7.x):** Use **Settings -> System -> Override Inform Host** Check the "Enable" box, and enter the IP address of the Docker host machine.
-* **Older:** Use **Settings -> Controller** Enter the IP address of the Docker host machine in "Controller Hostname/IP", and check the "Override inform host with controller hostname/IP". 
+For your Unifi devices to "find" the Unifi Controller running in Docker,
+you _MUST_ override the Inform Host IP
+with the address of the Docker host computer.
+(By default, the Docker container usually gets the address 172.17.x.x.)
+To do this:
 
-In either case, save settings and **restart UniFi-in-Docker container** with `docker stop ...` and `docker run ...`
+* Find **Settings -> System -> Override Inform Host:** in the Unifi Controller web GUI.
+* Check the "Enable" box, and enter the IP address of the Docker host machine. 
+* Save settings in Unifi Controller
+* Restart UniFi-in-Docker container with `docker stop ...` and `docker run ...` commands.
 
 ## Other Techniques for Adoption
 
-The following are not strictly required for your Unifi-in-Docker, but they collect information that may be helpful as you move to a new controller instance.
+The following are not strictly required for Unifi-in-Docker, but they collect information that may be helpful as you move to a new controller instance.
 
 ### Use Unifi export and migrate tool
 
-Unifi can export and migrate the APs to a new controller [see, for example](https://lazyadmin.nl/home-network/migrate-unifi-controller/) 
+Unifi can export and migrate the APs to a new controller [see this article for example.](https://lazyadmin.nl/home-network/migrate-unifi-controller/) 
 
 #### SSH Adoption
 
@@ -182,7 +211,14 @@ set-inform http://<docker-host-ip>:8080/inform
 
 #### Force Migration
 
-Force an AP to migrate using https://community.ui.com/questions/Migrating-UNIFI-APs-to-new-controller/9ca9d8e9-780d-404d-84df-e7762cb810fd
+Force an AP to migrate using [this Unifi community article.](https://community.ui.com/questions/Migrating-UNIFI-APs-to-new-controller/9ca9d8e9-780d-404d-84df-e7762cb810fd)
+
+#### Older versions of Unifi Controller
+
+Older Unifi Controllers use a different name for the "Override Inform Host option".
+Look for **Settings -> Controller:**
+Enter the IP address of the Docker host machine in "Controller Hostname/IP",
+and check the "Override inform host with controller hostname/IP". 
 
 #### Other Options
 
@@ -190,7 +226,7 @@ You can see more options on the [UniFi website](https://help.ubnt.com/hc/en-us/a
 
 ### Layer 2 Adoption
 
-The Layer 3 techniques above should be all you need to get new APs to adopt your controller running in Docker.
+The layer 3 techniques above should be all you need to get new APs to adopt your controller running in Docker.
 You can also configure the Docker instance so that its IP address matches its host address so that Layer 2 adoption works
 using either of these settings.
 
@@ -239,57 +275,33 @@ Under your containers service definition instead of using `image: jacobalberty/u
 
 Once again, simply change PKGURL to point to the package you would like to use.
 
-## Volumes:
+## Volumes
 
-### `/unifi`
+Unifi looks for the `/unifi` directory (within the container)
+for its special purpose subdirectories:
 
-This is a single monolithic volume that contains several subdirectories,
-you can do a single volume for everything or break up your old volumes into the subdirectories
+* `/unifi/data` This contains your UniFi configuration data. (formerly: `/var/lib/unifi`) 
 
-#### `/unifi/data`
+* `/unifi/log` This contains UniFi log files (formerly: `/var/log/unifi`)
 
-Old: `/var/lib/unifi`
-
-This contains your UniFi configuration data.
-
-#### `/unifi/log`
-
-old: `/var/log/unifi`
-
-This contains UniFi log files
-
-#### `/unifi/cert`
-
-old: `/var/cert/unifi`
-
-To use custom SSL certs, you must map a volume with the certs to /unifi/cert
-
+* `/unifi/cert` Place custom SSL certs in this directory. 
 For more information regarding the naming of the certificates,
-see [Certificate Support](#certificate-support).
+see [Certificate Support](#certificate-support). (formerly: `/var/cert/unifi`)
 
-#### `/unifi/init.d`
-
-This is an entirely new volume.
+* `/unifi/init.d`
 You can place scripts you want to launch every time the container starts in here
 
-### `/var/run/unifi`
-
+* `/var/run/unifi` 
 Run information, in general you will not need to touch this volume.
 It is there to ensure UniFi has a place to write its PID files
-
 
 ### Legacy Volumes
 
 These are no longer actually volumes, rather they exist for legacy compatibility.
 You are urged to move to the new volumes ASAP.
 
-#### `/var/lib/unifi`
-
-New name: `/unifi/data`
-
-#### `/var/log/unifi`
-
-New name: `/unifi/log`
+* `/var/lib/unifi` New name: `/unifi/data`
+* `/var/log/unifi` New name: `/unifi/log`
 
 ## Environment Variables:
 
@@ -297,135 +309,111 @@ You can pass in environment variables using the `-e` option when you invoke `doc
 See the `TZ` in the example above.
 Other environment variables:
 
-### `UNIFI_HTTP_PORT`
-
-Default: `8080`
-
+* `UNIFI_HTTP_PORT`
 This is the HTTP port used by the Web interface. Browsers will be redirected to the `UNIFI_HTTPS_PORT`.
+**Default:** `8080`
 
-### `UNIFI_HTTPS_PORT`
-
-Default: `8443`
-
+* `UNIFI_HTTPS_PORT`
 This is the HTTPS port used by the Web interface.
+**Default:** `8443`
 
-### `PORTAL_HTTP_PORT`
-
-Default: `80`
-
+* `PORTAL_HTTP_PORT`
 Port used for HTTP portal redirection.
+**Default:** `80`
 
-### `PORTAL_HTTPS_PORT`
-
-Default: `8843`
-
+* `PORTAL_HTTPS_PORT`
 Port used for HTTPS portal redirection.
+**Default:** `8843`
 
-### `UNIFI_STDOUT`
-
-Default: `unset`
-
+* `UNIFI_STDOUT`
 Controller outputs logs to stdout in addition to server.log
+**Default:** `unset`
 
-### `TZ`
-
+* `TZ`
 TimeZone. (i.e America/Chicago)
 
-### `JVM_MAX_THREAD_STACK_SIZE`
+* `JVM_MAX_THREAD_STACK_SIZE`
+Used to set max thread stack size for the JVM
+Example:
 
-used to set max thread stack size for the JVM
+   ```
+   --env JVM_MAX_THREAD_STACK_SIZE=1280k
+   ```
 
-Ex:
+   as a fix for https://community.ubnt.com/t5/UniFi-Routing-Switching/IMPORTANT-Debian-Ubuntu-users-MUST-READ-Updated-06-21/m-p/1968251#M48264
 
-```
---env JVM_MAX_THREAD_STACK_SIZE=1280k
-```
-
-as a fix for https://community.ubnt.com/t5/UniFi-Routing-Switching/IMPORTANT-Debian-Ubuntu-users-MUST-READ-Updated-06-21/m-p/1968251#M48264
-
-### `LOTSOFDEVICES`
-Enable this with `true` if you run a system with a lot of devices and/or
-with a low powered system (like a Raspberry Pi)
+* `LOTSOFDEVICES`
+Enable this with `true` if you run a system with a lot of devices
+and/or with a low powered system (like a Raspberry Pi).
 This makes a few adjustments to try and improve performance: 
 
-* enable unifi.G1GC.enabled
-* set unifi.xms to JVM_INIT_HEAP_SIZE
-* set unifi.xmx to JVM_MAX_HEAP_SIZE
-* enable unifi.db.nojournal
-* set unifi.dg.extraargs to --quiet
+   * enable unifi.G1GC.enabled
+   * set unifi.xms to JVM\_INIT\_HEAP\_SIZE
+   * set unifi.xmx to JVM\_MAX\_HEAP\_SIZE
+   * enable unifi.db.nojournal
+   * set unifi.dg.extraargs to --quiet
 
-See [This website](https://help.ui.com/hc/en-us/articles/115005159588-UniFi-How-to-Tune-the-Network-Application-for-High-Number-of-UniFi-Devices) for an explanation 
-of some of those options.
+   See [the Unifi support site](https://help.ui.com/hc/en-us/articles/115005159588-UniFi-How-to-Tune-the-Network-Application-for-High-Number-of-UniFi-Devices)
+for an explanation of some of those options.
+**Default:** `unset`
 
-Default: `unset`
-
-### `JVM_EXTRA_OPTS`
+* `JVM_EXTRA_OPTS`
 Used to start the JVM with additional arguments.
+**Default:** `unset`
 
-Default: `unset`
-
-### `JVM_INIT_HEAP_SIZE`
+* `JVM_INIT_HEAP_SIZE`
 Set the starting size of the javascript engine for example: `1024M`
+**Default:** `unset`
 
-Default: `unset`
-
-### `JVM_MAX_HEAP_SIZE`
+* `JVM_MAX_HEAP_SIZE`
 Java Virtual Machine (JVM) allocates available memory. 
 For larger installations a larger value is recommended. For memory constrained system this value can be lowered. 
-
-Default `1024M`
+**Default:** `1024M`
 
 ### External MongoDB environment variables
 
 These variables are used to implement support for an [external MongoDB server](https://community.ubnt.com/t5/UniFi-Wireless/External-MongoDB-Server/td-p/1305297) and must all be set in order for this feature to work. Once all are set then the configuration file value for `db.mongo.local` will automatically be set to `false`.
 
-### `DB_URI`
-
+* `DB_URI`
 Maps to `db.mongo.uri`.
 
-### `STATDB_URI`
-
+* `STATDB_URI`
 Maps to `statdb.mongo.uri`.
 
-### `DB_NAME`
-
+* `DB_NAME`
 Maps to `unifi.db.name`.
 
-
-## Expose:
+## Exposed Ports
 
 This container exposes the following ports. A minimal Unifi Controller requires the first three.
 
 * 8080/tcp - Device command/control
-
 * 8443/tcp - Web interface + API
-
 * 3478/udp - STUN service
-
 * 8843/tcp - HTTPS portal
-
 * 8880/tcp - HTTP portal
-
 * 6789/tcp - Speed Test (unifi5 only)
 
 See [UniFi - Ports Used](https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used) for more information.
 
 ## Multi-process container
+_[Is this section still true? Relevant?]_
 
-While micro-service patterns try to avoid running multiple processes in a container, the unifi5 container tries to follow the same process execution model intended by the original debian package and it's init script, while trying to avoid needing to run a full init system.
+While micro-service patterns try to avoid running multiple processes in a container, the unifi5 container tries to follow the same process execution model intended by the original debian package and its init script, while trying to avoid needing to run a full init system.
 
 `dumb-init` has now been removed. Instead it is now suggested you include --init in your docker run command line. If you are using docker-compose you can accomplish the same by making sure you use version 2.2 of the yml format and add `init: true` to your service definition.
 
 `unifi.sh` executes and waits on the jsvc process which orchestrates running the controller as a service. The wrapper script also traps SIGTERM to issue the appropriate stop command to the unifi java `com.ubnt.ace.Launcher` process in the hopes that it helps keep the shutdown graceful.
 
-
 ## Init scripts
+
+_[Is this section still true? Relevant?]_
 
 You may now place init scripts to be launched during the unifi startup in /usr/local/unifi/init.d to perform any actions unique to your unifi setup. An example bash script to set up certificates is in `/usr/unifi/init.d/import_cert`.
 
 ## Certificate Support
 
-To use custom SSL certs, you must map a volume with the certs to /unifi/cert
+To use custom SSL certs, you must map a volume with the certs to `/unifi/cert`
 
 They should be named:
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ See the [Volumes](#volumes) discussion for other volumes used by Unifi Controlle
 - `jacobalberty/unifi` - the name of the container to use.
 The `jacobalberty...` image is retrieved from [Dockerhub.](https://hub.docker.com/r/jacobalberty/unifi)
 See the discussion about [Supported Tags](#supported-docker-hub-tags-and-respective-dockerfile-links) below.
-- **Windows Users:** For information about running on Windows, see [Unifi-in-Docker on Windows](#unifi-in-docker-on-windows) below.
 
 ## Supported Tags
 
@@ -137,7 +136,7 @@ provides the most recent stable release.
 See the table below for the current version.
 
 The `rc` tag (for example, `jacobalberty/unifi:rc`)
-uses the most recent release candidate from the UniFi APT repository.
+uses the most recent Release Candidate from the UniFi APT repository.
 
 You may also specify a version number (e.g., `jacobalberty/unifi:stable6`)
 to get a specific version number, as shown in the table below.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You may also specify a version number (e.g., `jacobalberty/unifi:6.2.26`) to get
 
 | Tag | Description | Changelog |
 |-----|-------------|-----------|
-| [`latest`, `v7`, `v7.1`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.1.66 as of 2022-05-18 |[Change Log 7.1.66](https://community.ui.com/releases/UniFi-Network-Application-7-1-66/cf1208d2-3898-418c-b841-699e7b773fd4)|
+| [`latest`, `v7`, `v7.1`, `7.1.66`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.1.66 as of 2022-05-18 |[Change Log 7.1.66](https://community.ui.com/releases/UniFi-Network-Application-7-1-66/cf1208d2-3898-418c-b841-699e7b773fd4)|
 | [`development`](https://github.com/jacobalberty/unifi-docker/blob/7.1.67/Dockerfile) | Release Candidate: 7.1.67-rc as of yyyy-mm-dd | [Change Log 7.1.67-rc](https://community.ui.com/releases/UniFi-Network-Application-7-1-67/f85ec723-ae52-405b-8905-077afcc97bb5) |
 | `6.2.26` | Earlier 6.2.26 version | link to changelog |
 | `5.8.x` | Earlier 5.8.x version (if available) | link to changelog |

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ To install, a couple lines on the command-line starts the container.
 To upgrade, just stop the old container, and start up the new.
 It's really that simple.
 
-This container has been tested on Ubuntu, Debian, macOS,
+This container has been tested on Ubuntu, Debian, macOS, Windows,
 and even Raspberry Pi hardware.
-For information about running on Windows, see [Unifi-in-Docker on Windows](#unifi-in-docker-on-windows) below.
 
 ## Current Information
 
@@ -21,10 +20,12 @@ There are currently no hot-fix or CVE warnings affecting Unifi Controller.
 
 ## Setting up, Running, Stopping, Upgrading
 
-First, install Docker on the the "Docker host" -
+First, install Docker on the "Docker host" -
 the machine that will run the Docker
 and Unifi Controller software.
 Use any of the guides on the internet to install on your Docker host.
+For Windows, see the [Microsoft guide for installing Docker.](https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers)
+
 Then use the following steps to set up the directories
 and start the Docker container running.
 
@@ -159,10 +160,12 @@ For Unifi-in-Docker, this uses the most recent stable version.
 For your Unifi devices to "find" the Unifi Controller running in Docker,
 you _MUST_ override the Inform Host IP
 with the address of the Docker host computer.
-(By default, the Docker container usually gets the address 172.17.x.x.)
+(By default, the Docker container usually gets the internal address 172.17.x.x
+while Unifi devices connect to the (external) address of the Docker host.)
 To do this:
 
 * Find **Settings -> System -> Other Configuration -> Override Inform Host:** in the Unifi Controller web GUI.
+(It's near the bottom of that page.)
 * Check the "Enable" box, and enter the IP address of the Docker host machine. 
 * Save settings in Unifi Controller
 * Restart UniFi-in-Docker container with `docker stop ...` and `docker run ...` commands.
@@ -352,19 +355,24 @@ If you must do this, also pass the
 `--sysctl net.ipv4.ip_unprivileged_port_start=0`
 option on the `docker run...` to bind to whatever port you wish.
 
-## Unifi-in-Docker on Windows
-Unifi uses the Mongo database to store its data.
+~~## Unifi-in-Docker on Windows~~
+
+~~Unifi uses the Mongo database to store its data.
 Mongo uses the fsync() system call on its data files.
-Because of how Docker for Windows works, you can't bind mount `/unifi/db/data` on a Docker for Windows container.
+Because of how Docker for Windows works, you can't bind mount `/unifi/db/data` on a Docker for Windows container.~~
 
-The article [MongoDB on Windows in Minutes with Docker](https://blog.jeremylikness.com/blog/2018-12-27_mongodb-on-windows-in-minutes-with-docker/) also provides guidance for setting up a Docker Volume to work with Mongo database.
+~~The article [MongoDB on Windows in Minutes with Docker](https://blog.jeremylikness.com/blog/2018-12-27_mongodb-on-windows-in-minutes-with-docker/) also provides guidance for setting up a Docker Volume to work with Mongo database.~~
 
-As a simpler alternative,
+~~As a simpler alternative,
 use the `docker-compose` command as described
 in the next section since it uses a pre-built
-Mongo container that addresses the problem.
+Mongo container that addresses the problem.~~
 
-### Running with separate Mongo container
+## Running with separate Mongo container
+
+_[ Should we remove this section?
+The simple all-in-one container above works just fine
+for people who "just want it to work" ]_
 
 The `docker-compose.yml` file in this repository provides a
 single command that orchestrates all the actions required
@@ -412,10 +420,23 @@ So any major changes should apply cleanly against the `beta` branch.
 
 ### Installing Beta Builds On The Command Line
 
-Using the Beta build is pretty easy, just use the `jacobalberty/unifi:beta` image
-and pass in the environment variable `-e PKGURL=https://dl.ubnt.com/unifi/5.6.30/unifi_sysvinit_all.deb` to your usual command line.
+Using the Beta build is pretty easy:
+just substitute the correct URL from the Unifi site
+for the `PKGURL` parameter,
+and use `jacobalberty/unifi:beta` for the image
+like this:
 
-Simply replace the url to the debian package with the version you prefer.
+```bash
+docker run -d --init \
+   --restart=unless-stopped \
+   -p 8080:8080 -p 8443:8443 -p 3478:3478/udp \
+   -e TZ='Africa/Johannesburg' \
+   -v ~/unifi:/unifi \
+   --user unifi \
+   --name unifi \
+   -e PKGURL=https://dl.ubnt.com/unifi/5.6.30/unifi_sysvinit_all.deb \
+   jacobalberty/unifi:beta
+```
 
 ### Running the Beta Using `docker-compose.yml` 
 

--- a/Side-Projects.md
+++ b/Side-Projects.md
@@ -1,0 +1,157 @@
+# Side Projects and Background Info
+
+The [README.md](./README.md) document describes how to get
+Unifi-in-Docker running for the most common case -
+a single easy-to-use container that runs everything.
+
+This document describes background, side projects,
+or other information we discovered while producing the
+Unifi-in-Docker container. 
+
+## Running with separate Mongo container
+
+The `docker-compose.yml` file in this repository provides a
+single command that orchestrates all the actions required
+to bring up Mongo and Unifi Controller in separate containers,
+using named volumes for important directories.
+
+Simply copy the `docker-compose.yml` file
+to your host computer's local disk
+(or clone this repo) and run:
+
+```bash
+cd <directory with docker-compose.yml>
+docker-compose up -d 
+```
+
+**Setting Options:**
+
+* The `docker-compose.yml` file contains the options
+passed to Unifi Controller when it starts.
+Edit the `docker-compose.yml` file setting its values according to the 
+[Options on the command line.](./README.md#options-on-the-command-line)
+* _Optional:_ Add additional `-e <any-environment-variables-you-want>` to the `docker-compose up` line
+
+To change options to Unifi Controller::
+
+```bash
+cd <directory with docker-compose.yml>
+docker-compose down # this stops Unifi Controller and MongoDB
+# ... edit the options in the docker-compose.yml file ...
+docker-compose up ... # to resume operation
+```
+
+### External MongoDB environment variables
+
+These variables are used to implement support for an [external MongoDB server](https://community.ubnt.com/t5/UniFi-Wireless/External-MongoDB-Server/td-p/1305297) and must all be set in order for this feature to work. Once all are set then the configuration file value for `db.mongo.local` will automatically be set to `false`.
+
+* `DB_URI`
+Maps to `db.mongo.uri`.
+
+* `STATDB_URI`
+Maps to `statdb.mongo.uri`.
+
+* `DB_NAME`
+Maps to `unifi.db.name`.
+
+## Beta Users
+
+The `beta` image has been updated to support package installation at run time.
+With this change you can now install the beta releases on more systems,
+such as Synology.
+This should open up access to the beta program for more users of this docker image.
+
+**NOTE:** This Beta image only works if you run as root.
+It also may need updates to handle permissions to handle the
+`RUNAS_UID0=false` changes.
+If you have questions, look for or create an issue about this.
+
+If you would like to submit a new feature for the images,
+the beta branch is probably a good one to apply it against as well.
+I will be cleaing up the Dockerfile under beta and gradually pushing out
+the improvements to the other branches.
+So any major changes should apply cleanly against the `beta` branch.
+
+### Running Beta Builds from the Command Line
+
+Using the Beta build is pretty easy:
+just substitute the correct URL from the Unifi site
+for the `PKGURL` parameter,
+and use `jacobalberty/unifi:beta` for the image
+like this:
+
+```bash
+docker run -d --init \
+   --restart=unless-stopped \
+   -p 8080:8080 -p 8443:8443 -p 3478:3478/udp \
+   -e TZ='Africa/Johannesburg' \
+   -v ~/unifi:/unifi \
+   --name unifi \
+   -e PKGURL=https://dl.ubnt.com/unifi/5.6.30/unifi_sysvinit_all.deb \
+   jacobalberty/unifi:beta
+```
+
+### Running the Beta Using `docker-compose.yml` 
+
+In the containers service definition of the `docker-compose.yml` file, replace `image: jacobalberty/unifi` with the following:
+
+```shell
+        image: jacobalberty/unifi:beta
+         environment:
+          PKGURL: https://dl.ubnt.com/unifi/5.6.40/unifi_sysvinit_all.deb
+```
+
+Replace the PKGURL: link with a link to the package you want.
+
+## Init scripts
+
+You may now place init scripts to be launched during the unifi startup in /usr/local/unifi/init.d to perform any actions unique to your unifi setup. An example bash script to set up certificates is in `/usr/unifi/init.d/import_cert`.
+
+## Other Techniques for Adoption
+
+The following are not strictly required for Unifi-in-Docker,
+but they collect information that may be helpful as you
+move to a new controller instance.
+
+### Use Unifi export and migrate tool
+
+Unifi can export and migrate the APs to a new controller
+[see this article for example.](https://lazyadmin.nl/home-network/migrate-unifi-controller/) 
+
+#### SSH Adoption
+
+SSH into the device:
+```
+set-inform http://<docker-host-ip>:8080/inform
+```
+
+#### Force Migration
+
+Force an AP to migrate using [this Unifi community article.](https://community.ui.com/questions/Migrating-UNIFI-APs-to-new-controller/9ca9d8e9-780d-404d-84df-e7762cb810fd)
+
+#### Older versions of Unifi Controller
+
+Older Unifi Controllers use a different name for the "Override Inform Host option".
+Look for **Settings -> Controller:**
+Enter the IP address of the Docker host machine in "Controller Hostname/IP",
+and check the "Override inform host with controller hostname/IP". 
+
+#### Other Options
+
+You can see more options on the [UniFi website](https://help.ubnt.com/hc/en-us/articles/204909754-UniFi-Layer-3-methods-for-UAP-adoption-and-management)
+
+### Layer 2 Adoption
+
+The layer 3 techniques above should be all you need to get new APs to adopt your controller running in Docker.
+You can also configure the Docker instance so that its IP address matches its host address so that Layer 2 adoption works
+using either of these settings.
+
+#### Host Networking
+
+If you launch the container using host networking \(With the `--net=host` parameter on `docker run`\) Layer 2 adoption works as if the controller is installed on the host.
+
+#### Bridge Networking
+
+It is possible to configure the `macvlan` driver to bridge your container to the host's networking adapter.
+Specific instructions for this container are not yet available but you can read a write-up for docker at
+[collabnix.com/docker-17-06-swarm-mode-now-with-macvlan-support](http://collabnix.com/docker-17-06-swarm-mode-now-with-macvlan-support/).


### PR DESCRIPTION
Here's an updated README that I'm satisfied with. (That doesn't mean it's correct - only that I cannot find anything else to take out...)

Open Issues:

- This first one might be controversial - I made the change to make it simpler to explain and use (I hope). That is, I rewrote the `latest` definition to use the most recent STABLE version. Mostly so that if a newcomer requests `jacobalberty/unifi` they get a stable version not a release candidate
- Consequently, I also changed the README to say that people who _do_ want a release candidate should look for `:development`
- I listed all the tag versions in a single table. I don't know how to know if they're all available...
- Have I described "override host IP" correctly?
- I tweaked up the formatting of Volumes and Environment Variables. Did I get it right?
- It's hard to know what to recommend for Windows users. The mongo/fsync() hassle is confusing. Could we simply recommend people use `docker-compose`? How would they supply options?
- I marked a couple sections at the end, asking if they are still relevant. (They seem to talk about much older versions of Docker and/or Unifi) Perhaps they should be updated or removed: I don't know enough about them to say for sure.

That's all the intentional changes I can remember. Please review this carefully - I'm kind of a newcomer myself to Docker and Unifi. 

All comments welcomed. Thanks.

