### PR TITLE
[BUGFIX] corrections to make v7.3.76 run with non-UID0 deployments

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -192,7 +192,7 @@ if [[ "${@}" == "unifi" ]]; then
         ${UNIFI_CMD} &
     elif [ "${RUNAS_UID0}" == "false" ]; then
         if [ "${BIND_PRIV}" == "true" ]; then
-            if setcap 'cap_net_bind_service=+ep' "${JAVA_HOME}/jre/bin/java"; then
+            if setcap 'cap_net_bind_service=+ep' "${JAVA_HOME}/bin/java"; then
                 sleep 1
             else
                 log "ERROR: setcap failed, can not continue"

--- a/functions
+++ b/functions
@@ -10,7 +10,7 @@ set_java_home() {
         # For some reason readlink failed so lets just make some assumptions instead
         # We're assuming openjdk 8 since thats what we install in Dockerfile
         arch=`dpkg --print-architecture 2>/dev/null`
-        JAVA_HOME=/usr/lib/jvm/java-8-openjdk-${arch}
+        JAVA_HOME=/usr/lib/jvm/java-11-openjdk-${arch}
     fi
 }
 


### PR DESCRIPTION
## Description
Explain the **details** for making this change. What existing problem does the pull request solve?

## Motivation and Context

I run my deployment as RUNAS_UID0=false, updating to the v7.3.76 tag failed. Logs:

```
[2022-12-06 12:15:03,263] <docker-entrypoint> Cert directory found. Checking Certs
[2022-12-06 12:15:03,265] <docker-entrypoint> Cert has not changed, not updating controller.
[2022-12-06 12:15:03,268] <docker-entrypoint> Starting unifi controller service.
Failed to set capabilities on file `/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java' (No such file or directory)
The value of the capability argument is not permitted for a file. Or the file is not a regular (non-symlink) file
[2022-12-06 12:15:03,269] <docker-entrypoint> ERROR: setcap failed, can not continue
[2022-12-06 12:15:03,270] <docker-entrypoint> ERROR: You may either launch with -e BIND_PRIV=false and only use ports >1024
[2022-12-06 12:15:03,271] <docker-entrypoint> ERROR: or run this container as root with -e RUNAS_UID0=true
```
After changing the 2 lines in this request, rebuilding the container and re-deploying, the update proceeds normally. These 2 changes just correct a very small oversight.

Logs post-change:

```
docker logs unifi
[2022-12-06 12:16:30,727] <docker-entrypoint> Cert directory found. Checking Certs
[2022-12-06 12:16:30,729] <docker-entrypoint> Cert has not changed, not updating controller.
[2022-12-06 12:16:30,731] <docker-entrypoint> Starting unifi controller service.
[2022-12-06 12:16:31,744] <docker-entrypoint> INFO: Changing 'unifi' UID to '1000' and GID to '1000'
```

A warning did get thrown, but it appears to be related to UBNT's code, not the container. Logs of the warning:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.springframework.util.ReflectionUtils (file:/usr/lib/unifi/lib/spring-core-5.3.18.jar) to constructor java.lang.invoke.MethodHandles$Lookup(java.lang.Class)
WARNING: Please consider reporting this to the maintainers of org.springframework.util.ReflectionUtils
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

## How Has This Been Tested?

Rebuilt the container, re-deployed, verified that launch/update proceeded as it typically has in the past.

## Closing issues

Updating from v7.2.95 to v7.3.76 fails due to pathname changes in the move from java-8 to java-11. I changed 2 lines in 2 files.

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
