### PR TITLE
[DOC] Update README to mention UNIFI_ECC_CERT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,24 @@ If your certificate or private key have different names, you can set the environ
 
 For letsencrypt certs, we'll autodetect that and add the needed Identrust X3 CA Cert automatically. In case your letsencrypt cert is already the chained certificate, you can set the `CERT_IS_CHAIN` environment variable to `true`, e.g. `CERT_IS_CHAIN=true`. This option also works together with a custom `CERTNAME`.
 
+### Certificates Using Elliptic Curve Algorithms
+
+If your certs use elliptic curve algorithms, which currently seems to be the default with letsencrypt certs, you might additionally have to set the `UNIFI_ECC_CERT` environment variable to `true`, otherwise clients will fail to establish a secure connection. For example an attempt with `curl` will show:
+
+```shell
+% curl -vvv https://my.server.com:8443
+curl: (35) error:1404B410:SSL routines:ST_CONNECT:sslv3 alert handshake failure
+```
+
+You can check your certificate for this with the following command:
+
+```shell
+% openssl x509 -text < cert.pem | grep 'Public Key Algorithm'
+         Public Key Algorithm: id-ecPublicKey
+```
+
+If the output contains `id-ec` as shown in the example, then your certificate might be affected.
+
 ## Additional Information
 
 This document describes everything you need to get Unifi-in-Docker running.


### PR DESCRIPTION
## Description
This change documents the very useful but currently undocumented UNIFI_ECC_CERT env var.

## Motivation and Context
I lost a lot of time to issue #70 when I wanted to enable custom ECC SSL certs from Let's Encrypt. It turns out there is a very useful environment variable that makes this work, but it is currently undocumented.

## How Has This Been Tested?

I rendered the Markdown and verified that everything looks good.

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
