### PR TITLE
[TASK] Support for UniFi 7.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/arm/v7,linux/arm64/v8,linux/amd64
+          platforms: linux/arm64/v8,linux/amd64
           push: false
           load: false
           cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           context: .
           provenance: false
-          platforms: linux/arm/v7,linux/arm64/v8,linux/amd64
+          platforms: linux/arm64/v8,linux/amd64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.6-bullseye as permset
+FROM golang:1.21-bullseye as permset
 WORKDIR /src
 RUN git clone https://github.com/jacobalberty/permset.git /src && \
     mkdir -p /out && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/7.5.174-e258d1dd8c/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/7.5.174/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/7.5.169-2ec9b4cd24/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/7.5.174-e258d1dd8c/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM golang:1.20.4-bullseye as permset
+FROM golang:1.20.6-bullseye as permset
 WORKDIR /src
 RUN git clone https://github.com/jacobalberty/permset.git /src && \
     mkdir -p /out && \
     go build -ldflags "-X main.chownDir=/unifi" -o /out/permset
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/7.4.162/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/7.5.169-2ec9b4cd24/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ For Unifi-in-Docker, this uses the most recent stable version.
 
 | Tag | Description | Changelog |
 |-----|-------------|-----------|
-| [`latest` `v7.4.162`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.4.162 as of 2023-07-03 |[Change Log 7.4.162](https://community.ui.com/releases/UniFi-Network-Application-7-4-162/50b4b930-631e-4ada-87c4-0b4ea5fb26a7)|
+| [`latest` `v7.5.174`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.5.174 as of 2023-09-04 |[Change Log 7.5.174](https://community.ui.com/releases/UniFi-Network-Application-7-5-174/d05b091f-f00c-4ebb-8f42-b77e0adac78b)|
 | [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile) | Release Candidate: 7.2.92-rc as of 2022-07-29 | [Change Log 7.2.91-rc](https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65) |
 | [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
 | [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -36,7 +36,7 @@ apt-get install -qy --no-install-recommends \
     dirmngr \
     gpg \
     gpg-agent \
-    openjdk-11-jre-headless \
+    openjdk-17-jre-headless \
     procps \
     libcap2-bin \
     tzdata

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,7 +54,7 @@ JVM_MAX_HEAP_SIZE=${JVM_MAX_HEAP_SIZE:-1024M}
 
 
 MONGOLOCK="${DATAPATH}/db/mongod.lock"
-JVM_EXTRA_OPTS="${JVM_EXTRA_OPTS} -Dunifi.datadir=${DATADIR} -Dunifi.logdir=${LOGDIR} -Dunifi.rundir=${RUNDIR}"
+JVM_EXTRA_OPTS="${JVM_EXTRA_OPTS} --add-opens=java.base/java.time=ALL-UNNAMED -Dunifi.datadir=${DATADIR} -Dunifi.logdir=${LOGDIR} -Dunifi.rundir=${RUNDIR}"
 PIDFILE=/var/run/unifi/unifi.pid
 
 if [ ! -z "${JVM_MAX_HEAP_SIZE}" ]; then

--- a/functions
+++ b/functions
@@ -10,7 +10,7 @@ set_java_home() {
         # For some reason readlink failed so lets just make some assumptions instead
         # We're assuming openjdk 8 since thats what we install in Dockerfile
         arch=`dpkg --print-architecture 2>/dev/null`
-        JAVA_HOME=/usr/lib/jvm/java-11-openjdk-${arch}
+        JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${arch}
     fi
 }
 


### PR DESCRIPTION
## Description
UniFi 7.5 requires JRE 17. This forces a move from Ubuntu 18.04-LTS to 20.04-LTS, as there aren't JRE 17 packages for 18.04. I couldn't move to 22.04-LTS, since that doesn't include mongodb packages any longer. "Official" mongodb repository no longer offers v3.6, so that leaves 20.04 as the only currently viable Ubuntu base image version.

There was a small JRE 17 related issue with java.time. The [fix](https://stackoverflow.com/questions/70412805/what-does-this-error-mean-java-lang-reflect-inaccessibleobjectexception-unable) was to add `--add-opens=java.base/java.time=ALL-UNNAMED` to the JVM_EXTRA_OPTS variable in the entrypoint script.

## Motivation and Context
Motivation was to provide an avenue to update to UniFi 7.5.

## How Has This Been Tested?
Builds cleanly, runs without incident on 3 sites I've tested with.

## Closing issues
Closes #673 
Closes #679 

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
