### PR TITLE
[BUGFIX] Update docker compose flow

### DIFF
--- a/Side-Projects.md
+++ b/Side-Projects.md
@@ -24,7 +24,7 @@ cd <directory with docker-compose.yml>
 docker compose up -d 
 ```
 
-Now as long as you don't `docker compose down`, the docker daemon (`sudo systemctl enable docker`) will automatically start the various containers every time the Pi boots.
+Now as long as you don't `docker compose down`, the docker daemon (`sudo systemctl enable docker`) will automatically start the various containers every time the host boots.
 
 **Logs:**
 

--- a/Side-Projects.md
+++ b/Side-Projects.md
@@ -21,8 +21,14 @@ to your host computer's local disk
 
 ```bash
 cd <directory with docker-compose.yml>
-docker-compose up -d 
+docker compose up -d 
 ```
+
+Now as long as you don't `docker compose down`, the docker daemon (`sudo systemctl enable docker`) will automatically start the various containers every time the Pi boots.
+
+**Logs:**
+
+Run `docker attach unifi_logs` to tail the various unifi logs files.
 
 **Setting Options:**
 
@@ -30,15 +36,15 @@ docker-compose up -d
 passed to Unifi Controller when it starts.
 Edit the `docker-compose.yml` file setting its values according to the 
 [Options on the command line.](./README.md#options-on-the-command-line)
-* _Optional:_ Add additional `-e <any-environment-variables-you-want>` to the `docker-compose up` line
+* _Optional:_ Add additional `-e <any-environment-variables-you-want>` to the `docker compose up` line
 
 To change options to Unifi Controller::
 
 ```bash
 cd <directory with docker-compose.yml>
-docker-compose down # this stops Unifi Controller and MongoDB
+docker compose down # this stops Unifi Controller and MongoDB
 # ... edit the options in the docker-compose.yml file ...
-docker-compose up ... # to resume operation
+docker compose up ... # to resume operation
 ```
 
 ### External MongoDB environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 name: unifi
 services:
   mongo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '2.3'
+version: '3'
+name: unifi
 services:
   mongo:
     image: mongo:3.6
@@ -48,6 +49,7 @@ services:
     depends_on:
       - controller
     command: bash -c 'tail -F /unifi/log/*.log'
+    tty: true
     restart: always
     volumes:
       - log:/unifi/log


### PR DESCRIPTION
## Description
* Add `tty: true` to docker-compose.yml so Ctrl-C works to stop watching logs
* Document how to watch the logs
* docker-compose (note the hyphen) is deprecated and unsupported as of July 2023: https://docs.docker.com/compose/reference/ . Update docs to `docker compose` (no hyphen)
* Update docker-compose.yml to latest version (3)

## How Has This Been Tested?

Tested locally. Before I had manually `kill` the `docker attach unifi_logs` command from a separate shell. Now Ctrl-C works.

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
