### PR TITLE
Update to 8.0.24 Official

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/8.0.2-fdee17d54f/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/8.0.6-fae0c5cdd1/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/8.0.6-fae0c5cdd1/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/8.0.7-7a3d06144a/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/8.0.7-7a3d06144a/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/8.0.7/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/8.0.7/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/8.0.24-450f174e64/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/7.5.176/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/8.0.2-fdee17d54f/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ For Unifi-in-Docker, this uses the most recent stable version.
 
 | Tag | Description | Changelog |
 |-----|-------------|-----------|
-| [`latest` `v8.0.7`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 8.0.7 as of 2023-11-20 |[Change Log 8.0.7](https://community.ui.com/releases/UniFi-Network-Application-8-0-7/7818b9df-4845-4c82-ba3c-1218e61010d4)|
+| [`latest` `v8.0.24`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 8.0.24 as of 2023-12-12 |[Change Log 8.0.24](https://community.ui.com/releases/UniFi-Network-Application-8-0-24/43b24781-aea8-48dc-85b2-3fca42f758c9)|
 | [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile) | Release Candidate: 7.2.92-rc as of 2022-07-29 | [Change Log 7.2.91-rc](https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65) |
 | [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
 | [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ For Unifi-in-Docker, this uses the most recent stable version.
 |-----|-------------|-----------|
 | [`latest` `v7.5.176`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.5.176 as of 2023-09-15 |[Change Log 7.5.176](https://community.ui.com/releases/UniFi-Network-Application-7-5-176/0a224764-0603-4a8b-a038-1a7d59c6615c)|
 | [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile) | Release Candidate: 7.2.92-rc as of 2022-07-29 | [Change Log 7.2.91-rc](https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65) |
+| [`beta`](https://github.com/jacobalberty/unifi-docker/blob/beta/Dockerfile) | Early Access: 8.0.2-ea as of 2023-10-20 | [Change Log 8.0.2-ea](https://community.ui.com/releases/UniFi-Network-Application-8-0-2/29c6c92e-9198-46d1-b45d-c685c9fd4523) |
 | [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
 | [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For Unifi-in-Docker, this uses the most recent stable version.
 |-----|-------------|-----------|
 | [`latest` `v7.5.176`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.5.176 as of 2023-09-15 |[Change Log 7.5.176](https://community.ui.com/releases/UniFi-Network-Application-7-5-176/0a224764-0603-4a8b-a038-1a7d59c6615c)|
 | [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile) | Release Candidate: 7.2.92-rc as of 2022-07-29 | [Change Log 7.2.91-rc](https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65) |
-| [`beta`](https://github.com/jacobalberty/unifi-docker/blob/beta/Dockerfile) | Early Access: 8.0.2-ea as of 2023-10-20 | [Change Log 8.0.2-ea](https://community.ui.com/releases/UniFi-Network-Application-8-0-6/759cb11f-e7a5-45ff-b2c7-c1bad3ffa18a) |
+| [`beta`](https://github.com/jacobalberty/unifi-docker/blob/beta/Dockerfile) | Early Access: 8.0.6-ea as of 2023-11-07 | [Change Log 8.0.6-ea](https://community.ui.com/releases/UniFi-Network-Application-8-0-6/759cb11f-e7a5-45ff-b2c7-c1bad3ffa18a) |
 | [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
 | [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For Unifi-in-Docker, this uses the most recent stable version.
 |-----|-------------|-----------|
 | [`latest` `v7.5.176`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.5.176 as of 2023-09-15 |[Change Log 7.5.176](https://community.ui.com/releases/UniFi-Network-Application-7-5-176/0a224764-0603-4a8b-a038-1a7d59c6615c)|
 | [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile) | Release Candidate: 7.2.92-rc as of 2022-07-29 | [Change Log 7.2.91-rc](https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65) |
-| [`beta`](https://github.com/jacobalberty/unifi-docker/blob/beta/Dockerfile) | Early Access: 8.0.2-ea as of 2023-10-20 | [Change Log 8.0.2-ea](https://community.ui.com/releases/UniFi-Network-Application-8-0-2/29c6c92e-9198-46d1-b45d-c685c9fd4523) |
+| [`beta`](https://github.com/jacobalberty/unifi-docker/blob/beta/Dockerfile) | Early Access: 8.0.2-ea as of 2023-10-20 | [Change Log 8.0.2-ea](https://community.ui.com/releases/UniFi-Network-Application-8-0-6/759cb11f-e7a5-45ff-b2c7-c1bad3ffa18a) |
 | [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
 | [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |
 

--- a/README.md
+++ b/README.md
@@ -149,9 +149,8 @@ For Unifi-in-Docker, this uses the most recent stable version.
 
 | Tag | Description | Changelog |
 |-----|-------------|-----------|
-| [`latest` `v7.5.176`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.5.176 as of 2023-09-15 |[Change Log 7.5.176](https://community.ui.com/releases/UniFi-Network-Application-7-5-176/0a224764-0603-4a8b-a038-1a7d59c6615c)|
+| [`latest` `v8.0.7`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 8.0.7 as of 2023-11-20 |[Change Log 8.0.7](https://community.ui.com/releases/UniFi-Network-Application-8-0-7/7818b9df-4845-4c82-ba3c-1218e61010d4)|
 | [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile) | Release Candidate: 7.2.92-rc as of 2022-07-29 | [Change Log 7.2.91-rc](https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65) |
-| [`beta`](https://github.com/jacobalberty/unifi-docker/blob/beta/Dockerfile) | Early Access: 8.0.7-ea as of 2023-11-10 | [Change Log 8.0.7-ea](https://community.ui.com/releases/UniFi-Network-Application-8-0-7/ee1af5a3-2bf9-440f-aa2d-4a296f44f2b9) |
 | [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
 | [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For Unifi-in-Docker, this uses the most recent stable version.
 |-----|-------------|-----------|
 | [`latest` `v7.5.176`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 7.5.176 as of 2023-09-15 |[Change Log 7.5.176](https://community.ui.com/releases/UniFi-Network-Application-7-5-176/0a224764-0603-4a8b-a038-1a7d59c6615c)|
 | [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile) | Release Candidate: 7.2.92-rc as of 2022-07-29 | [Change Log 7.2.91-rc](https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65) |
-| [`beta`](https://github.com/jacobalberty/unifi-docker/blob/beta/Dockerfile) | Early Access: 8.0.6-ea as of 2023-11-07 | [Change Log 8.0.6-ea](https://community.ui.com/releases/UniFi-Network-Application-8-0-6/759cb11f-e7a5-45ff-b2c7-c1bad3ffa18a) |
+| [`beta`](https://github.com/jacobalberty/unifi-docker/blob/beta/Dockerfile) | Early Access: 8.0.7-ea as of 2023-11-10 | [Change Log 8.0.7-ea](https://community.ui.com/releases/UniFi-Network-Application-8-0-7/ee1af5a3-2bf9-440f-aa2d-4a296f44f2b9) |
 | [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
 | [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |
 


### PR DESCRIPTION
## Description
The new Network 8.x branch is Official so updating. There are currently reports that 8.0.7 is incompatible with 3rd party routers and 3rd party DHCP/RADIUS.

## Motivation and Context
Allows users to use the new 8.0.7 version.
Closes: https://github.com/jacobalberty/unifi-docker/issues/693 https://github.com/jacobalberty/unifi-docker/issues/702

## How Has This Been Tested?
Hopes and dreams. UI hasn't changed any dependencies so if anything breaks, it'll be on Ubiquiti.

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.