### PR TITLE
[TASK] Update to ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN git clone https://github.com/jacobalberty/permset.git /src && \
     mkdir -p /out && \
     go build -ldflags "-X main.chownDir=/unifi" -o /out/permset
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
@@ -34,9 +34,9 @@ ENV BASEDIR=/usr/lib/unifi \
 # This should be integrated with the main run because it duplicates a lot of the steps there
 # but for now while shoehorning gosu in it is seperate
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y gosu; \
-	rm -rf /var/lib/apt/lists/*
+    apt-get update; \
+    apt-get install -y gosu; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/unifi \
      /usr/local/unifi/init.d \


### PR DESCRIPTION
## Description
- updated base image to Ubuntu 22.04, closes #528
- removed the use of deprecated `apt-key` in `docker-build.sh`
- added mongodb repository to installed supported mongodb version (v3.6 according to [this article](https://help.ui.com/hc/en-us/articles/220066768-UniFi-How-to-Install-and-Update-via-APT-on-Debian-or-Ubuntu))
- removed unused functions in `docker-build.sh` 

## How Has This Been Tested?
Builds and runs locally (amd64), don't have access to arm HW though
Tested with `podman version 4.4.4`, `docker version 24.0.5-ce, build a61e2b4c9`and is currently running my controller on kubernets `v1.27.6+k3s1`

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
