### PR TITLE
Complete the readme with configuring the AP inform endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ See [Side Projects](https://github.com/jacobalberty/unifi-docker/blob/master/Sid
 other techniques to get Unifi devices to adopt your
 new Unifi Controller.
 
+#### Configure the Inform endpoint in the AP (optional)
+
+In case the AP is not showing up for adoption after completing the steps described above, you need to configure the inform endpoint within the AP as well. You will have to SSH into the device and run a command:
+* Once the AP is connected to the local network and it's fully booted, check its IP address.
+For the sake of the example let's say it's 192.168.2.102.
+* Using this IP address and the factory default username (`ubnt`) and password (`ubnt`), SSH into the AP:
+   ```bash
+   $ ssh ubnt@192.168.2.102 -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa
+   ```
+  _Note that the username and password may be different in your system. You can check it in the Unifi Controller under Settings > System > Advanced > Device Authentication._
+* Once the SSH connection is successful, configure the inform endpoint inside the AP:
+   ```bash
+   $ set-inform http://ip-of-your-docker-host-computer:8080/inform
+   ```
+* After issuing the `set-inform` command, the AP should show up for adoption. As per this [comment](https://community.ui.com/questions/Controler-unable-to-see-Unifi-devices/11f674cb-9b83-4bdb-bbce-03e86c4dfdfa#answer/53944d82-d469-41da-964b-798482aa5aa6), after adoption the AP may appear to go offline after which the `set-inform` command may need to be run again to make it permanent.
+
 ## Volumes
 
 Unifi looks for the `/unifi` directory (within the container)


### PR DESCRIPTION
Address the update to the README suggested in https://github.com/jacobalberty/unifi-docker/issues/686.

Note that there is not much discussion on the issue itself but the information provided already seems to have helped one or two users. The issue has recently been flagged with the `no-issue-activity` so before it disappears and gets swept under the rug, here's a pull request that adds some additional provisioning steps to the readme file.

## Description
After completing the steps explaind in the _Adopting Access Points and Unifi Devices_, the AP may still not appear for adoption. In this case some configuration inside the AP may be necessary. These additional steps are described in the added paragraph.

## Motivation and Context
The readme feels incomplete without mentioning the configuration changes in the AP. Following the current guide may not result in a working setup and users have to search the internet to gather the missing pieces of information.

Closes #686.

## Checklist:
- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
