### PR TITLE
[TASK] Update controller to v8.0.26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.idea/
+.vscode/
+.DS_Store
 backup/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/8.0.24-450f174e64/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/8.0.26/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ _Note:_ In Docker, specifying an image with no tag
 (e.g., `jacobalberty/unifi`) gets the "latest" tag.
 For Unifi-in-Docker, this uses the most recent stable version.
 
-| Tag | Description | Changelog |
-|-----|-------------|-----------|
-| [`latest` `v8.0.24`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 8.0.24 as of 2023-12-12 |[Change Log 8.0.24](https://community.ui.com/releases/UniFi-Network-Application-8-0-24/43b24781-aea8-48dc-85b2-3fca42f758c9)|
-| [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile) | Release Candidate: 7.2.92-rc as of 2022-07-29 | [Change Log 7.2.91-rc](https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65) |
-| [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile) | Final stable version 6 (6.5.55) | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e) |
-| [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile) | Final stable version 5 (5.4.23) | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a) |
+| Tag                                                                                       | Description                                     | Changelog                                                                                                                       |
+|-------------------------------------------------------------------------------------------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| [`latest` `v8.0.26`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 8.0.26 as of 2023-12-28 | [Change Log 8.0.26](https://community.ui.com/releases/UniFi-Network-Application-8-0-26/cd9303a8-f26a-44e2-94d8-a3cac8606726)    |
+| [`rc`](https://github.com/jacobalberty/unifi-docker/blob/rc/Dockerfile)                   | Release Candidate: 7.2.92-rc as of 2022-07-29   | [Change Log 7.2.91-rc](https://community.ui.com/releases/UniFi-Network-Application-7-2-91/cdac73f0-7426-4276-ace8-8a96c656ba65) |
+| [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile)       | Final stable version 6 (6.5.55)                 | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e)    |
+| [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile)       | Final stable version 5 (5.4.23)                 | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a)   |
 
 ### multiarch
 


### PR DESCRIPTION
## Description
Bumps version of unifi controller to v8.0.26

## Motivation and Context
I'm running into WAN port issues on my UXG after updating to v8.0.24 that I believe will be resolved with v8.0.26, based on their release notes.  The issues happen randomly, thus I won't know for sure until some more time has passed.

Either way, v8.0.26 is their latest stable version.

## How Has This Been Tested?

I have built and pushed my own version here: https://hub.docker.com/repository/docker/dancarbone/jacobalberty-unifi/general.

I am now running this version on the pi4 I use as my unifi controller host without issue.

## Closing issues

Closes #714 

## Checklist:
- [X] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
