### PR TITLE
[DOC] Adding documentation to update 11 year old directionss

### DIFF
--- a/Side-Projects.md
+++ b/Side-Projects.md
@@ -129,6 +129,8 @@ set-inform http://<docker-host-ip>:8080/inform
 
 Force an AP to migrate using [this Unifi community article.](https://community.ui.com/questions/Migrating-UNIFI-APs-to-new-controller/9ca9d8e9-780d-404d-84df-e7762cb810fd)
 
+In the case the above 'reset to default' command in step 2 does not work for your AP, you could also try this command [from this article](https://blog.linitx.com/factory-reset-ubiquiti-unifi-access-point/): `syswrapper.sh restore-default & set-default &`
+
 #### Older versions of Unifi Controller
 
 Older Unifi Controllers use a different name for the "Override Inform Host option".


### PR DESCRIPTION
The current `Force Migration` directions can fail to fully reset an Ubiquit AP. It appears sometimes the restore-default command does not complete restore defaults and a following 'set-default' command is needed to ensure a successful factory reset.

This PR updates the documentation under `Side-Projects.md` to include a comment stating that if the linked solution doesn't work to fully reset the AP to a default state you can run this command: `syswrapper.sh restore-default & set-default &`

ISSUE #723


## Description
The current documentation did not work for me, so I updated it with my solution. 

## Motivation and Context
Will help others avoid this headache in the future

## How Has This Been Tested?

N/A

## Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
