### PR TITLE
Adjust inform host wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ with the address of the Docker host computer.
 while Unifi devices connect to the (external) address of the Docker host.)
 To do this:
 
-* Find **Settings -> System -> Other Configuration -> Override Inform Host:** in the Unifi Controller web GUI.
+* Find **Settings -> System -> Advanced -> Inform Host:** in the Unifi Controller web GUI and enabled the checkbox **Override**.
 (It's near the bottom of that page.)
 * Check the "Enable" box, and enter the IP address of the Docker host machine. 
 * Save settings in Unifi Controller

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ with the address of the Docker host computer.
 while Unifi devices connect to the (external) address of the Docker host.)
 To do this:
 
-* Find **Settings -> System -> Advanced -> Inform Host:** in the Unifi Controller web GUI and enabled the checkbox **Override**.
+* Find **Settings -> System -> Advanced -> Inform Host:** in the Unifi Controller web GUI.
 (It's near the bottom of that page.)
 * Check the "Enable" box, and enter the IP address of the Docker host machine. 
 * Save settings in Unifi Controller


### PR DESCRIPTION
Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above.

Please provide enough information so that others can review your pull request:

## Description
The current README shows an outdated? path to the Inform Host Override setting. The current view:

![grafik](https://github.com/jacobalberty/unifi-docker/assets/87267/ba81cf33-e8bd-4a65-994d-0ba14ee6160e)


## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
