### PR TITLE
[TASK] Update Ubuntu and add RC 8.1.127

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,17 @@ WORKDIR /src
 RUN git clone https://github.com/jacobalberty/permset.git /src && \
     mkdir -p /out && \
     go build -ldflags "-X main.chownDir=/unifi" -o /out/permset
-
-FROM ubuntu:20.04
+	
+#Update from 20.04 to 22.04 test
+FROM ubuntu:22.04
 
 LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/8.1.113/unifi_sysvinit_all.deb
-
+#Add PKGURL for 8.1.127 RC Release
+#ARG PKGURL=https://dl.ui.com/unifi/8.1.113/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/8.1.127-810cd1e59a/unifi_sysvinit_all.deb
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \
     LOGDIR=/unifi/log \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -39,9 +39,19 @@ apt-get install -qy --no-install-recommends \
     openjdk-17-jre-headless \
     procps \
     libcap2-bin \
-    tzdata
+    tzdata 
+
+curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | \
+   gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg \
+   --dearmor
+
+echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+
 echo 'deb https://www.ui.com/downloads/unifi/debian stable ubiquiti' | tee /etc/apt/sources.list.d/100-ubnt-unifi.list
 tryfail apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 06E85760C0A52C50
+
+apt-get update
+apt-get install -qy --no-install-recommends mongodb-org
 
 if [ -d "/usr/local/docker/pre_build/$(dpkg --print-architecture)" ]; then
     find "/usr/local/docker/pre_build/$(dpkg --print-architecture)" -type f -exec '{}' \;


### PR DESCRIPTION
Updated to Ubuntu 22.04, fixed MongoDB Issue and change apkurl to 8.1.127 for RC. Fix that should be implemented is mongodb fix and ubuntu2204 at least for amd64

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:

## Description
Fixed Ubuntu 20.04 to working 22.04.

## Motivation and Context
I wanted to add APKURL to be RC compatible.

## How Has This Been Tested?

Made push to safhdev/unifi-docker:test, its a private one for now but the pull and start works.
Build was fine too, had to fix an issue due to mongodb.


## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
