### PR TITLE
If CERT_IS_CHAIN or ca.pem and chain.pem don't exist, then just take the cert file as is.

### DIFF
--- a/import_cert
+++ b/import_cert
@@ -71,10 +71,14 @@ _EOF
         awk 1 "${CERTTEMPFILE}" "${CERTDIR}/${CERTNAME}" >> "${CHAIN}"
     elif [[ "${CERTURI}" == *"lencr.org"* ]]; then
         awk 1 "${CERTTEMPFILE}" "${CERTDIR}/chain.pem" "${CERTDIR}/${CERTNAME}" >> "${CHAIN}"
+    elif [[ "$CERT_IS_CHAIN" == "true" ]]; then
+        cat "${CERTDIR}/${CERTNAME}" >> "${CHAIN}"
     elif [[ -f "${CERTDIR}/ca.pem" ]]; then
         awk 1 "${CERTDIR}/ca.pem" "${CERTDIR}/chain.pem" "${CERTDIR}/${CERTNAME}" >> "${CHAIN}"
-    else
+    elif [[ -f "${CERTDIR}/chain.pem" ]]; then
         awk 1 "${CERTDIR}/chain.pem" "${CERTDIR}/${CERTNAME}" >> "${CHAIN}"
+    else
+        cat "${CERTDIR}/${CERTNAME}" >> "${CHAIN}"
     fi
    openssl pkcs12 -export  -passout pass:aircontrolenterprise \
         -in "${CHAIN}" \


### PR DESCRIPTION
Fixes #752 by providing additional fallback if ca.pem and chain.pem aren't provided.

This allows certification chains that are not signed by letsencrypt to work when the full chain is provided as a single file.