### PR TITLE
[BUGFIX] Docker labels should be labels from metadata not tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,6 +72,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.tags }} 
+          labels: ${{ steps.meta.outputs.labels }} 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
## Description
Populate docker labels with the labels generated by docker metadata step, not the tags

## Motivation and Context
Renovate and other dependancy updaters don't know where the release notes / changelogs are coming from because they are missing the common opencontainer 

## How Has This Been Tested?

(Awaiting Build)

## Closing issues

Closes #774 774

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
