### PR TITLE
[DOC] Adding pass through of UDP port 10001 by default to make device adoption easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Each of the options is [described below.](#options-on-the-command-line)
 ```bash
 docker run -d --init \
    --restart=unless-stopped \
-   -p 8080:8080 -p 8443:8443 -p 3478:3478/udp \
+   -p 8080:8080 -p 8443:8443 -p 3478:3478/udp -p 10001:10001/udp \
    -e TZ='Africa/Johannesburg' \
    -v ~/unifi:/unifi \
    --user unifi \
@@ -107,7 +107,7 @@ The options for the `docker run...` command are:
 - `--restart=unless-stopped` - If the container should stop for some reason,
 restart it unless you issue a `docker stop ...`
 - `-p ...` - Set the ports to pass through to the container.
-`-p 8080:8080 -p 8443:8443 -p 3478:3478/udp`
+`-p 8080:8080 -p 8443:8443 -p 3478:3478/udp -p 10001:10001/udp`
 is the minimal set for a working Unifi Controller. 
 - `-e TZ=...` Set an environment variable named `TZ` with the desired time zone.
 Find your time zone in this 
@@ -280,15 +280,15 @@ For larger installations a larger value is recommended. For memory constrained s
 
 The Unifi-in-Docker container exposes the following ports.
 A minimal Unifi Controller installation requires you
-expose the first three with the `-p ...` option.
+expose the first four with the `-p ...` option.
 
 * 8080/tcp - Device command/control 
 * 8443/tcp - Web interface + API 
 * 3478/udp - STUN service 
+* 10001/udp - Device discovery
 * 8843/tcp - HTTPS portal _(optional)_
 * 8880/tcp - HTTP portal _(optional)_
 * 6789/tcp - Speed Test (unifi5 only) _(optional)_
-* 10001/udp - Used for device discovery _(optional)_
 
 See [UniFi - Ports Used](https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used) for more information.
 

--- a/Side-Projects.md
+++ b/Side-Projects.md
@@ -83,7 +83,7 @@ like this:
 ```bash
 docker run -d --init \
    --restart=unless-stopped \
-   -p 8080:8080 -p 8443:8443 -p 3478:3478/udp \
+   -p 8080:8080 -p 8443:8443 -p 3478:3478/udp -p 10001:10001/udp \
    -e TZ='Africa/Johannesburg' \
    -v ~/unifi:/unifi \
    --name unifi \


### PR DESCRIPTION
## Description
Unfortunately device adoption of new devices does not work from the UniFi web UI using the default Docker command suggested in the readme file without manually adding UDP port 10001.

## Motivation and Context
Adding pass through of UDP port 10001 to the suggested Docker command in the readme file will make device adoption from the web UI work for new devices. The issue #794 has been started to discuss this and no one has, at the time of writing, responded with any technical reason for not having the pass though of this port by default.

## How Has This Been Tested?
Have tested the new command on an OpenWrt 24.10.1 system and a macOS 15.4.1 system and new devices show up in the web UI automatically ready for adoption with this change. Did also help another user in issue #795 where this change was used and it worked for them as well. They ran the container on an OpenWrt 24.10-SNAPSHOT system.

## Closing issues
Closes #794

## Checklist:
- [X] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.