### PR TITLE
Update the documentations to reflect the controller changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ with the address of the Docker host computer.
 while Unifi devices connect to the (external) address of the Docker host.)
 To do this:
 
-* Find **Settings -> System -> Other Configuration -> Override Inform Host:** in the Unifi Controller web GUI.
-(It's near the bottom of that page.)
+* Find **UniFi Devices -> Device Updates and Settings -> Device Settings -> Inform Host Override:** in the Unifi Controller web GUI.
+(It's in the middle of that page.)
 * Check the "Enable" box, and enter the IP address of the Docker host machine. 
 * Save settings in Unifi Controller
 * Restart UniFi-in-Docker container with `docker stop ...` and `docker run ...` commands.


### PR DESCRIPTION
[DOC] v9.3.43 has a different layout of the menu for the inform host override  option.