### PR TITLE
[BUGFIX] Fix casing warning.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bullseye as permset
+FROM golang:1.22-bullseye AS permset
 WORKDIR /src
 RUN git clone https://github.com/jacobalberty/permset.git /src && \
     mkdir -p /out && \


### PR DESCRIPTION
## Description
Fixes a warning on `docker build ....` due to casing differences.

## Motivation and Context
Eliminates a stray warning.

## How Has This Been Tested?
Tested with `docker build ...` on the command line in Ubuntu.

## Closing issues

closes #819 
