### PR TITLE
[BUGFIX] Replace Slart with Start in the new StartTLS param

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ Port used for HTTPS portal redirection.
 Controller outputs logs to stdout in addition to server.log
 **Default: unset**
 
-* `SMTP_SLARTTLS_ENABLED`
-Disable SlartTLS for SMTP. Required when the SMTP server do not support encryption
+* `SMTP_STARTTLS_ENABLED`
+Disable StartTLS for SMTP. Required when the SMTP server do not support encryption
 **Default: unset** 
 
 * `TZ`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -154,8 +154,8 @@ if ! [[ -z "$UNIFI_HTTPS_PORT"  ]]; then
   settings["unifi.https.port"]="$UNIFI_HTTPS_PORT"
 fi
 
-if ! [[ -z "$SMTP_SLARTTLS_ENABLED"  ]]; then
-  settings["smtp.starttls_enabled"]="SMTP_SLARTTLS_ENABLED"
+if ! [[ -z "$SMTP_STARTTLS_ENABLED"  ]]; then
+  settings["smtp.starttls_enabled"]="$SMTP_STARTTLS_ENABLED"
 fi
 
 if [[ "$UNIFI_ECC_CERT" == "true" ]]; then


### PR DESCRIPTION
Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:

## Description
Fixes the issues from #826  found by @crowbarz 

## Motivation and Context
On review @crowbarz found the parameter was misnamed as `slart` and was missing the `$` to evaluate it as a variable. This corrects that

## How Has This Been Tested?

Validated via shellcheck
