### PR TITLE
[BUGFIX] Updates to address ULP infinite error spawning in 9.5.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,13 @@ ENV BASEDIR=/usr/lib/unifi \
     UNIFI_GID=999 \
     UNIFI_UID=999
 
-# Install gosu
+# Install gosu and python3
 # https://github.com/tianon/gosu/blob/master/INSTALL.md
 # This should be integrated with the main run because it duplicates a lot of the steps there
 # but for now while shoehorning gosu in it is seperate
 RUN set -eux; \
 	apt-get update; \
-	apt-get install -y gosu; \
+	apt-get install -y gosu python3; \
 	rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/unifi \
@@ -45,13 +45,17 @@ RUN mkdir -p /usr/unifi \
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY docker-healthcheck.sh /usr/local/bin/
 COPY docker-build.sh /usr/local/bin/
+COPY ucore-manifest-server.py /usr/local/bin/
 COPY functions /usr/unifi/functions
 COPY import_cert /usr/unifi/init.d/
+COPY start_ucore_server /usr/unifi/init.d/
 COPY pre_build /usr/local/docker/pre_build
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
  && chmod +x /usr/unifi/init.d/import_cert \
  && chmod +x /usr/local/bin/docker-healthcheck.sh \
  && chmod +x /usr/local/bin/docker-build.sh \
+ && chmod +x /usr/local/bin/ucore-manifest-server.py \
+ && chmod +x /usr/unifi/init.d/start_ucore_server \
  && chmod -R +x /usr/local/docker/pre_build
 
 # Push installing openjdk-8-jre first, so that the unifi package doesn't pull in openjdk-7-jre as a dependency? Else uncomment and just go with openjdk-7.

--- a/start_ucore_server
+++ b/start_ucore_server
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Start the ucore manifest server in the background
+if [ -f /usr/local/bin/ucore-manifest-server.py ]; then
+    /usr/local/bin/ucore-manifest-server.py > /dev/null 2>&1 &
+    echo "Started ucore manifest server on 127.0.0.1:9080"
+fi

--- a/ucore-manifest-server.py
+++ b/ucore-manifest-server.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/api/ucore/manifest':
+            body = b"{}"
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(401)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+
+HTTPServer(("127.0.0.1", 9080), Handler).serve_forever()


### PR DESCRIPTION
Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:

## Description
To resolve issue #840, I added the suggested Python script from the Unifi Community to start at container launch. This is a temporary fix to the ULP issue that prevents container log errors from being clobbered by this message.

## Motivation and Context
Solving a bug in the current version.

## How Has This Been Tested?
Tested in freshly-upgraded v9.4.x to v9.5.21 deployment. Logs indicate ULP error has been stopped.
```
[2025-11-08 18:55:46,797] <docker-entrypoint> Cert directory found. Checking Certs
[2025-11-08 18:55:46,808] <docker-entrypoint> Cert has not changed, not updating controller.
Started ucore manifest server on 127.0.0.1:9080
[2025-11-08 18:55:46,837] <docker-entrypoint> Starting unifi controller service.
[2025-11-08 18:55:51,265] <launcher> INFO  startup - Initiating startup
[2025-11-08 18:55:52,133] <launcher> INFO  system - ======================================================================
[2025-11-08 18:55:52,134] <launcher> INFO  system - UniFi 9.5.21 (build atag_9.5.21_31260 - release/release) is started
[2025-11-08 18:55:52,138[] <launcher> INFO  system - Environment: UniFi-OS[false[], UniFi-Cloud[false[], UniFi-MongoService[false]
[2025-11-08 18:55:52,138] <launcher> INFO  system - ======================================================================
[2025-11-08 18:55:52,139] <launcher> INFO  system - BASE dir:/usr/lib/unifi
[2025-11-08 18:55:52,158] <launcher> INFO  system - Current System IP: 10.80.5.201
[2025-11-08 18:55:52,165] <launcher> INFO  system - Hostname: unifi-56f5597d9c-hx5wt
[2025-11-08 18:55:52,166] <launcher> INFO  system - ubic.env: prod
[2025-11-08 18:55:52,166] <launcher> INFO  system - System loaded
[2025-11-08 18:55:52,287] <launcher> INFO  mongo  - Checking if database needs to be shut down
[2025-11-08 18:55:53,632] <launcher> INFO  mongo  - Database was not running
[2025-11-08 18:55:53,633] <launcher> INFO  mongo  - Starting database process...
[2025-11-08 18:55:58,941] <launcher> INFO  mongo  - Database process is started
[2025-11-08 18:55:58,979] <launcher> INFO  mongo  - Connected to database (v3.6.8@mongodb://localhost:27117, journal enabled)
[2025-11-08 18:55:59,002[] <launcher> WARN  startup -   component[mongoRuntimeService] initialization took 6715ms
[2025-11-08 18:55:59,571] <launcher> INFO  db     - Starting database service initialization...
[2025-11-08 18:55:59,939] <launcher> INFO  db     - Database service initialized...
[2025-11-08 18:55:59,940[] <launcher> WARN  startup -   component[configDbService] initialization took 368ms
[2025-11-08 18:56:01,066] <launcher> INFO  tomcat - Adding basic REST API support during the startup
[2025-11-08 18:56:02,444] <launcher> INFO  system - Tomcat startup took 11151ms
[2025-11-08 18:56:59,976] <launcher> INFO  webrtc - WebRTC library version: EvoStream Media Server (www.evostream.com) build v2.9.1 - Gladiator - (built for Debian-8.2.0-x86_64 on 2020-02-05T23:33:19.000) OpenSSL version: 1.1.1d usrsctp version: v0.1.2 compiled on machine: Linux debian-8-2-0-64 3.16.0-6-amd64 #1 SMP Debian 3.16.57-2 (2018-07-14) x86_64 GNU/Linux
[2025-11-08 18:57:25,380] <launcher> INFO  startup - Context ready
[2025-11-08 18:57:25,401] <launcher> INFO  migration - Version 9.5.21 has not changed, skipping migration
[2025-11-08 18:57:25,801] <launcher> INFO  startup - Calling context ready handlers
[2025-11-08 18:57:26,213[] <launcher> INFO  productinfo - [UIDB] Initializing UiDbService
[2025-11-08 18:57:27,125[] <launcher> INFO  productinfo - Using controller channel=RELEASE, firmware channel=RELEASE. Available controller channels=[RELEASE, RELEASE_CANDIDATE, BETA[], available firmware channels=[RELEASE, RELEASE_CANDIDATE, BETA]. SSO is enabled.
[2025-11-08 18:57:27,851] <launcher> WARN  topology - removed topology link 84:78:48:2a:cc:8c -> 6c:63:f8:30:e8:c6
[2025-11-08 18:57:27,859] <launcher> INFO  startup - Done with context ready handlers
[2025-11-08 18:57:27,860] <launcher> INFO  tomcat - Removing basic REST API support
[2025-11-08 18:57:27,870] <launcher> INFO  startup - Startup complete
[2025-11-08 18:57:27,881] <launcher> INFO  tomcat - systemd: Watchdog ping NOT enabled
[2025-11-08 18:57:27,884] <launcher> INFO  tomcat - systemd: Startup completed. Ready for watchdog keep-alive checking.
[2025-11-08 18:57:27,982] <launcher> INFO  sdnotify - ubnt_sdnotify_jni is loaded from: /usr/lib/unifi/lib/native/Linux/x86_64/libubnt_sdnotify_jni.so
[2025-11-08 18:57:28,835] <cloudaccess-connect> WARN  VersionInfoUtils - The AWS SDK for Java 1.x entered maintenance mode starting July 31, 2024 and will reach end of support on December 31, 2025. For more information, see https://aws.amazon.com/blogs/developer/the-aws-sdk-for-java-1-x-is-in-maintenance-mode-effective-july-31-2024/
You can print where on the file system the AWS SDK for Java 1.x core runtime is located by setting the AWS_JAVA_V1_PRINT_LOCATION environment variable or aws.java.v1.printLocation system property to 'true'.
This message can be disabled by setting the AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT environment variable or aws.java.v1.disableDeprecationAnnouncement system property to 'true'.
The AWS SDK for Java 1.x is being used here:
at java.base/java.lang.Thread.getStackTrace(Thread.java:1619)
at com.amazonaws.util.VersionInfoUtils.printDeprecationAnnouncement(VersionInfoUtils.java:81)
at com.amazonaws.util.VersionInfoUtils.<clinit>(VersionInfoUtils.java:59)
at com.amazonaws.ClientConfiguration.<clinit>(ClientConfiguration.java:95)
at com.ubnt.service.sdn.oO0o.Øöo000(Unknown Source)
at com.ubnt.service.sdn.oO0o.Õôo000(Unknown Source)
at com.ubnt.service.sdn.oO0o.forvoidsuper(Unknown Source)
at com.ubnt.service.system.thread.OoOO.OO0000(Unknown Source)
at com.ubnt.ace.A.A.run(Unknown Source)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
at java.base/java.lang.Thread.run(Thread.java:840)
[2025-11-08 18:57:29,555] <cloudaccess-connect> WARN  ApacheUtils - NoSuchMethodException was thrown when disabling normalizeUri. This indicates you are using an old version (< 4.5.8) of Apache http client. It is recommended to use http client version >= 4.5.9 to avoid the breaking change introduced in apache client 4.5.7 and the latency in exception handling. See https://github.com/aws/aws-sdk-java/issues/1919 for more information
[2025-11-08 18:58:26,346[] <sync-uidb> INFO  productinfo - [UIDB] Sync external UiDb Snapshot
[2025-11-08 18:58:26,991[] <sync-uidb> INFO  productinfo - [UIDB] Sync UiDb Records of private models
```

## Closing issues

Put `closes #840` in your comment to auto-close the issue that your PR fixes (if such).

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
