### PR TITLE
 [TASK] Bump UniFi Network Application from 9.5.21 to 10.0.162.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/10.0.160/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/10.0.162/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ _Note:_ In Docker, specifying an image with no tag
 (e.g., `jacobalberty/unifi`) gets the "latest" tag.
 For Unifi-in-Docker, this uses the most recent stable version.
 
-| Tag                                                                                         | Description                                       | Changelog                                                                                                                       |
-|---------------------------------------------------------------------------------------------|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| [`latest` `v10.0.160`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 10.0.160 as of 2025-11-26 | [Change Log 10.0.160](https://community.ui.com/releases/UniFi-Network-Application-10-0-160/ce7adc5c-4b42-49d3-8447-971992c0bced) |
-| [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile)         | Final stable version 6 (6.5.55)                   | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e)    |
-| [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile)         | Final stable version 5 (5.4.23)                   | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a)   |
+| Tag                                                                                         | Description                                       | Changelog                                                                                                                        |
+|---------------------------------------------------------------------------------------------|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| [`latest` `v10.0.162`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 10.0.162 as of 2025-12-04 | [Change Log 10.0.162](https://community.ui.com/releases/UniFi-Network-Application-10-0-162/2efd581a-3a55-4c36-80bf-1267dbfc2aee) |
+| [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile)         | Final stable version 6 (6.5.55)                   | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e)     |
+| [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile)         | Final stable version 5 (5.4.23)                   | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a)    |
 
 ### multiarch
 


### PR DESCRIPTION
## Description

Update Network Application version from 9.5.21 to 10.0.162.

## Motivation and Context

Update UniFi Network to official release version 10.0.162. The new version includes improvements and bugfixes, as described [here](https://community.ui.com/releases/UniFi-Network-Application-10-0-162/2efd581a-3a55-4c36-80bf-1267dbfc2aee).

## How Has This Been Tested?

1. Built the container on a local home server, 
2. Accessed and completed the default UniFi setup without any issues,
3. Connected an Access Point, passed a VLAN network and configured an SSID,
4. Connected to the SSID successfully using a mobile device. 

PKGURL in Dockerfile points to new, official release from December 04, 2025.

## Closing issues

none

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
