### PR TITLE
Update UniFi Network Application to v10.1.85

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/10.0.162/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/10.1.85/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \
@@ -54,7 +54,6 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
  && chmod +x /usr/local/bin/docker-build.sh \
  && chmod -R +x /usr/local/docker/pre_build
 
-# Push installing openjdk-8-jre first, so that the unifi package doesn't pull in openjdk-7-jre as a dependency? Else uncomment and just go with openjdk-7.
 RUN set -ex \
  && mkdir -p /usr/share/man/man1/ \
  && groupadd -r unifi -g $UNIFI_GID \

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For Unifi-in-Docker, this uses the most recent stable version.
 
 | Tag                                                                                         | Description                                       | Changelog                                                                                                                        |
 |---------------------------------------------------------------------------------------------|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| [`latest` `v10.0.162`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 10.0.162 as of 2025-12-04 | [Change Log 10.0.162](https://community.ui.com/releases/UniFi-Network-Application-10-0-162/2efd581a-3a55-4c36-80bf-1267dbfc2aee) |
+| [`latest` `v10.1.85`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 10.1.85 as of 2026-02-11 | [Change Log 10.1.85](https://community.ui.com/releases/UniFi-Network-Application-10-1-85/364f40ee-6976-4299-803e-89e111020f91) |
 | [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile)         | Final stable version 6 (6.5.55)                   | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e)     |
 | [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile)         | Final stable version 5 (5.4.23)                   | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a)    |
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -36,10 +36,42 @@ apt-get install -qy --no-install-recommends \
     dirmngr \
     gpg \
     gpg-agent \
-    openjdk-17-jre-headless \
     procps \
     libcap2-bin \
     tzdata
+
+# --- temurin-25-jdk (required by unifi.deb on newer Ubuntu) ---
+apt install -y wget apt-transport-https gpg
+wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
+
+echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+
+apt-get update
+apt-get install -qy --no-install-recommends \
+  temurin-25-jre
+# --- end temurin-25-jdk ---
+
+# --- MongoDB (required by unifi.deb on newer Ubuntu) ---
+apt-get update
+apt-get install -qy --no-install-recommends ca-certificates gnupg
+
+install -d /usr/share/keyrings
+curl -fsSL https://pgp.mongodb.com/server-4.4.asc \
+  | gpg --dearmor -o /usr/share/keyrings/mongodb-server-4.4.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-server-4.4.gpg] \
+https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" \
+  > /etc/apt/sources.list.d/mongodb-org-4.4.list
+
+apt-get update
+
+# Pin to 4.4 so we never pull an update (unifi wants < 8.1.0)
+apt-get install -qy --no-install-recommends \
+  mongodb-org-server=4.4.* mongodb-org-shell=4.4.* mongodb-org-mongos=4.4.* mongodb-org-tools=4.4.*
+
+apt-mark hold mongodb-org-server mongodb-org-shell mongodb-org-mongos mongodb-org-tools
+# --- end MongoDB ---
+
 echo 'deb https://www.ui.com/downloads/unifi/debian stable ubiquiti' | tee /etc/apt/sources.list.d/100-ubnt-unifi.list
 tryfail apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 06E85760C0A52C50
 

--- a/functions
+++ b/functions
@@ -10,7 +10,7 @@ set_java_home() {
         # For some reason readlink failed so lets just make some assumptions instead
         # We're assuming openjdk 8 since thats what we install in Dockerfile
         arch=`dpkg --print-architecture 2>/dev/null`
-        JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${arch}
+        JAVA_HOME=/usr/lib/jvm/java-25-openjdk-${arch}
     fi
 }
 


### PR DESCRIPTION
## Summary

This pull request updates the UniFi Network Application to **v10.1.85**.

Changes include:
* Updated `PKGURL` to reference UniFi Network Application 10.1.85.
* Upgraded MongoDB from **3.6 → 4.4**, as UniFi 10.1.85 no longer supports MongoDB 3.6.
* Upgraded Java runtime to **Temurin (Eclipse Adoptium) JDK 25** to satisfy UniFi 10.1.85 requirements.
      * Switched to `temurin-25-jdk` due to OpenJDK package availability issues in Ubuntu and to ensure compatibility with the UniFi 10.1.85 dependency requirements.
* Verified successful build and runtime on `amd64`.

Note: armhf was not upgraded or tested as part of this change.

### MongoDB Upgrade Notes

MongoDB 4.4 introduces WiredTiger format changes that are not backward-compatible with databases created under MongoDB 3.6. As a result, existing persistent database files cannot be reused directly when upgrading.

The recommended migration path is:

1. Create a UniFi application backup (`.unf` file).
2. Remove the existing MongoDB data directory.
3. Upgrade the container.
4. Restore the `.unf` backup.

This provides a clean and supported upgrade path.

### Architecture Notes

* `amd64` tested and confirmed working.
* `armhf` was not upgraded or tested as part of this change.

---

## Related issues

closes #872, "Update UniFi Network Application to v10.1.85"

---

## Checklist

* [x] My changes build and run locally (where applicable).
* [x] I’ve reviewed Dockerfile/README changes for accuracy (if affected).
* [x] I’m open to feedback and ready to adjust this PR if needed.
