### PR TITLE
Change directory references from legacy /var/run/unifi to current /unifi/run

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ see [Certificate Support](#certificate-support). (formerly: `/var/cert/unifi`)
 * `/unifi/init.d`
 You can place scripts you want to launch every time the container starts in here
 
-* `/var/run/unifi` 
+* `/unifi/run` 
 Run information, in general you will not need to touch this volume.
 It is there to ensure UniFi has a place to write its PID files
 
@@ -215,6 +215,7 @@ It is there to ensure UniFi has a place to write its PID files
 These are no longer actually volumes, rather they exist for legacy compatibility.
 You are urged to move to the new volumes ASAP.
 
+* `/var/run/unifi` New name: `/unifi/run`
 * `/var/lib/unifi` New name: `/unifi/data`
 * `/var/log/unifi` New name: `/unifi/log`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - log:/unifi/log
       - cert:/unifi/cert
       - init:/unifi/init.d
-      - run:/var/run/unifi
+      - run:/unifi/run
       # Mount local folder for backups and autobackups
       - ./backup:/unifi/data/backup
     user: unifi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -55,7 +55,7 @@ JVM_MAX_HEAP_SIZE=${JVM_MAX_HEAP_SIZE:-1024M}
 
 MONGOLOCK="${DATAPATH}/db/mongod.lock"
 JVM_EXTRA_OPTS="${JVM_EXTRA_OPTS} --add-opens=java.base/java.time=ALL-UNNAMED -Dunifi.datadir=${DATADIR} -Dunifi.logdir=${LOGDIR} -Dunifi.rundir=${RUNDIR}"
-PIDFILE=/var/run/unifi/unifi.pid
+PIDFILE=${RUNDIR}/unifi.pid
 
 if [ ! -z "${JVM_MAX_HEAP_SIZE}" ]; then
   JVM_EXTRA_OPTS="${JVM_EXTRA_OPTS} -Xmx${JVM_MAX_HEAP_SIZE}"
@@ -74,8 +74,8 @@ JVM_OPTS="${JVM_EXTRA_OPTS}
   -Djava.awt.headless=true
   -Dfile.encoding=UTF-8"
 
-# Cleaning /var/run/unifi/* See issue #26, Docker takes care of exlusivity in the container anyway.
-rm -f /var/run/unifi/unifi.pid
+# Cleaning PIDFILE See issue #26, Docker takes care of exlusivity in the container anyway.
+rm -f ${PIDFILE}
 
 run-parts /usr/local/unifi/init.d
 run-parts /usr/unifi/init.d

--- a/examples/fixing_backup_errors/README.md
+++ b/examples/fixing_backup_errors/README.md
@@ -65,7 +65,7 @@ services:
       - log:/unifi/log
       - cert:/unifi/cert
       - init:/unifi/init.d
-      - run:/var/run/unifi
+      - run:/unifi/run
       # Mount local folder for backups and autobackups
       - ./backup:/unifi/data/backup
     user: unifi


### PR DESCRIPTION
## Summary

Gets rid of the references to legacy path /var/run/unifi
and replace them with the current /unifi/run.

## Related issues

None.


## Checklist

A quick self-check before submitting:

- [x] My changes build and run locally (where applicable).
- [x] I’ve reviewed Dockerfile/README changes for accuracy (if affected).
- [x] I’m open to feedback and ready to adjust this PR if needed.

