### PR TITLE
Dockerfile: chmod +r on COPY'd files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,12 @@ COPY docker-build.sh /usr/local/bin/
 COPY functions /usr/unifi/functions
 COPY import_cert /usr/unifi/init.d/
 COPY pre_build /usr/local/docker/pre_build
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
- && chmod +x /usr/unifi/init.d/import_cert \
- && chmod +x /usr/local/bin/docker-healthcheck.sh \
- && chmod +x /usr/local/bin/docker-build.sh \
- && chmod -R +x /usr/local/docker/pre_build
+RUN chmod +rx /usr/local/bin/docker-entrypoint.sh \
+ && chmod +rx /usr/unifi/init.d/import_cert \
+ && chmod +r  /usr/unifi/functions \
+ && chmod +rx /usr/local/bin/docker-healthcheck.sh \
+ && chmod +rx /usr/local/bin/docker-build.sh \
+ && chmod -R +rx /usr/local/docker/pre_build
 
 # Push installing openjdk-8-jre first, so that the unifi package doesn't pull in openjdk-7-jre as a dependency? Else uncomment and just go with openjdk-7.
 RUN set -ex \


### PR DESCRIPTION
otherwise this is problematic for docker builder where the git repo was clone'd/check'ed out with a restrictive umask

fixes #881 