### PR TITLE
only stamp md5 after successful cert import

### DIFF
--- a/import_cert
+++ b/import_cert
@@ -58,7 +58,6 @@ Ob8VZRzI9neWagqNdwvYkQsEjgfbKbYK7p2CNTUQ
 _EOF
 
     log "Cert has changed, updating controller..."
-    md5sum "${CERTDIR}/${CERTNAME}" > "${CERTDIR}/${CERTNAME}.md5"
     log "Using openssl to prepare certificate..."
     CHAIN=$(mktemp)
     TMPLIST+=" ${CHAIN}"
@@ -95,6 +94,7 @@ _EOF
         -srckeystore "${TEMPFILE}" -srcstoretype PKCS12 \
         -srcstorepass aircontrolenterprise \
         -alias unifi
+    md5sum "${CERTDIR}/${CERTNAME}" > "${CERTDIR}/${CERTNAME}.md5"
     log "Cleaning up temp files"
     for file in ${TMPLIST}; do
         rm -f "${file}"


### PR DESCRIPTION
## Summary

Fix `import_cert` writing the md5 checksum before the cert is actually imported into the keystore. If `keytool -importkeystore` (or any earlier step) fails, the md5 still gets stamped, so subsequent runs see a matching md5 and skip the import, leaving the controller serving the old cert until it expires.

- Move md5sum write to after `keytool -importkeystore` succeeds.
- No behaviour change on the happy path; failures now correctly retry on the next run instead of being silently masked.


## Related issues

N/A

## Checklist

A quick self-check before submitting:

- [x] My changes build and run locally (where applicable).
- [x] I’ve reviewed Dockerfile/README changes for accuracy (if affected).
- [x] I’m open to feedback and ready to adjust this PR if needed.