### PR TITLE
Update to the base image to support later Network Application versions + Update to 10.1.89

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN git clone https://github.com/jacobalberty/permset.git /src && \
     mkdir -p /out && \
     go build -ldflags "-X main.chownDir=/unifi" -o /out/permset
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PKGURL=https://dl.ui.com/unifi/10.0.162/unifi_sysvinit_all.deb
+ARG PKGURL=https://dl.ui.com/unifi/10.1.89/unifi_sysvinit_all.deb
 
 ENV BASEDIR=/usr/lib/unifi \
     DATADIR=/unifi/data \

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ For Unifi-in-Docker, this uses the most recent stable version.
 
 | Tag                                                                                         | Description                                       | Changelog                                                                                                                        |
 |---------------------------------------------------------------------------------------------|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| [`latest` `v10.0.162`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 10.0.162 as of 2025-12-04 | [Change Log 10.0.162](https://community.ui.com/releases/UniFi-Network-Application-10-0-162/2efd581a-3a55-4c36-80bf-1267dbfc2aee) |
+| [`latest` `v10.1.89`](https://github.com/jacobalberty/unifi-docker/blob/master/Dockerfile) | Current Stable: Version 10.1.89 as of 2026-02-13 | [Change Log 10.1.89](https://community.ui.com/releases/UniFi-Network-Application-10-1-89/625f366f-7ea5-4266-bd9f-500180494035) |
 | [`stable-6`](https://github.com/jacobalberty/unifi-docker/blob/stable-6/Dockerfile)         | Final stable version 6 (6.5.55)                   | [Change Log 6.5.55](https://community.ui.com/releases/UniFi-Network-Application-6-5-55/48c64137-4a4a-41f7-b7e4-3bee505ae16e)     |
 | [`stable-5`](https://github.com/jacobalberty/unifi-docker/blob/stable-5/Dockerfile)         | Final stable version 5 (5.4.23)                   | [Change Log 5.14.23](https://community.ui.com/releases/UniFi-Network-Controller-5-14-23/daf90732-30ad-48ee-81e7-1dcb374eba2a)    |
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,41 @@ and even Raspberry Pi hardware.
 **Latest Version:** The latest version is shown in the first line
 of the [Current Information](#current-information) table on this page.
 
+## Breaking Changes beyond 10.0.162
+
+To be able to install 10.1.84 or later, there is a new requirement of Java 25.
+To install Java 25 via package, it means we need to move to Ubuntu 22.04 or later.
+Doing that also means we need to upgrade MongoDB to at least version 6 as there is 
+no way to install 3.6, 4.x, 5.x with packages from MongoDB cleanly, as the Unifi package will check for dependencies.
+
+This also means there is no clean upgrade path here now, as there is no simple way to do the DB upgrade in place.
+It will mean the process needs to be:
+ - Backup
+ - New install
+ - Restore
+
+To upgrade to this new image means you need to take a backup from the Unifi Network Application
+and save the `network_backup_<date>_v<version>.unf` file before you upgrade.
+
+It is also a good idea you take a full backup of the current `./unifi` mount too. 
+
+Once you have taken the "backups", you will now need to stop the current Network Application and 
+remove all data from your `unifi/` mount so that it is empty to start a new install
+
+Then you can pull the new image that has been built with:
+ - Ubuntu 24.04
+ - Java 25
+ - MongoDB 6.0
+
+On starting the new container, it will be a new install that you will need to select `Restore Server from a Backup` then `Upload Backup File`
+
+### MongoDB support
+
+With this image from now on, MongoDB has been pushed to version 6.0 which now has a requirement
+ for AVX support in the host cpu(s). This may be an issue for older systems. In this case 
+you will be best off splitting out the Network Application and MongoDB into two separate 
+containers and thus can continue to run MongoDB 4.4
+
 ## Setting up, Running, Stopping, Upgrading
 
 First, install Docker on the "Docker host" -

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -31,15 +31,26 @@ fi
 
 apt-get update
 apt-get install -qy --no-install-recommends \
-    apt-transport-https \
+    binutils \
+    ca-certificates \
     curl \
     dirmngr \
     gpg \
     gpg-agent \
-    openjdk-17-jre-headless \
-    procps \
     libcap2-bin \
+    logrotate \
+    openjdk-25-jre-headless \
+    procps \
+    software-properties-common \
     tzdata
+
+# Install MongoDB 6 - as the Unifi deb package will check
+
+curl -Ls https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor -o /usr/share/keyrings/mongo.gpg
+echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongo.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+apt update
+apt install -qy mongodb-org-server
+
 echo 'deb https://www.ui.com/downloads/unifi/debian stable ubiquiti' | tee /etc/apt/sources.list.d/100-ubnt-unifi.list
 tryfail apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 06E85760C0A52C50
 


### PR DESCRIPTION
## Summary

Update to the base image to support later Network Application versions
 - Update base image from Ubuntu 20.04 to 24.02
 - Update to Java 25
 - Update to MongoDB 6.0

MongoDB is now installed from the MongoDB repo and version 6.0 is the lowest that is supported on 24.02

Also updated Network Application URL to 10.1.89

## Related issues

If this PR is connected to any issues, list them here.

You can use keywords like:
- closes #527 
- closes #528 

## Checklist

A quick self-check before submitting:

- [X] My changes build and run locally (where applicable).
- [X] I’ve reviewed Dockerfile/README changes for accuracy (if affected).
- [X] I’m open to feedback and ready to adjust this PR if needed.

## Testing

I have run the the build on both my Mac (ARM64) and an Intel NUC (x84_64)
The image has been deployed and run a new install of Network Application 10.1.89
Also restored a backup from 9.5.21 and it's started up and all seems to be working.

Thanks
Josh