### PR TITLE
Update base image to Ubuntu 26.04 and add mongodb from project repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN git clone https://github.com/jacobalberty/permset.git /src && \
     mkdir -p /out && \
     go build -ldflags "-X main.chownDir=/unifi" -o /out/permset
 
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 
 LABEL maintainer="Jacob Alberty <jacob.alberty@foundigital.com>"
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -3,27 +3,6 @@
 # fail on error
 set -e
 
-# Retry 5 times with a wait of 10 seconds between each retry
-tryfail() {
-    for i in $(seq 1 5);
-        do [ $i -gt 1 ] && sleep 10; $* && s=0 && break || s=$?; done;
-    (exit $s)
-}
-
-# Try multiple keyservers in case of failure
-addKey() {
-    for server in $(shuf -e ha.pool.sks-keyservers.net \
-        hkp://p80.pool.sks-keyservers.net:80 \
-        keyserver.ubuntu.com \
-        hkp://keyserver.ubuntu.com:80 \
-        pgp.mit.edu) ; do \
-        if apt-key adv --keyserver "$server" --recv "$1"; then
-            exit 0
-        fi
-    done
-    return 1
-}
-
 if [ "x${1}" == "x" ]; then
     echo please pass PKGURL as an environment variable
     exit 0
@@ -40,8 +19,12 @@ apt-get install -qy --no-install-recommends \
     procps \
     libcap2-bin \
     tzdata
-echo 'deb https://www.ui.com/downloads/unifi/debian stable ubiquiti' | tee /etc/apt/sources.list.d/100-ubnt-unifi.list
-tryfail apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 06E85760C0A52C50
+
+curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
+echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+apt-get update
+curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x06e85760c0a52c50" | gpg -o /usr/share/keyrings/unifi.gpg --dearmor
+echo 'deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/unifi.gpg ] https://www.ui.com/downloads/unifi/debian stable ubiquiti' | tee /etc/apt/sources.list.d/100-ubnt-unifi.list
 
 if [ -d "/usr/local/docker/pre_build/$(dpkg --print-architecture)" ]; then
     find "/usr/local/docker/pre_build/$(dpkg --print-architecture)" -type f -exec '{}' \;


### PR DESCRIPTION
## Summary

Update base image to Ubuntu 26.04 and add mongodb from project repository

Example:
 - Update to Ubuntu 26.04 base image
 - Update mongodb dependency 

## Checklist

A quick self-check before submitting:

- [x] My changes build and run locally (where applicable).
- [x] I’ve reviewed Dockerfile/README changes for accuracy (if affected).
- [x] I’m open to feedback and ready to adjust this PR if needed.

---

Thanks again for helping improve the project! 🙌
